### PR TITLE
add RCropRatio operation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,4 +2,6 @@
 
 New operations:
 
-- `CropRatio`: crop down to the specified aspect ratio.
+- `CropRatio`: crop to the specified aspect ratio around the center.
+
+- `RCropRatio`: crop random window with the specified aspect ratio.

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ look at the corresponding section of the
 |               | `CropNative`        | Crop specific region of the image in relative space.
 |               | `CropSize`          | Crop area around the center with specified size.
 |               | `CropRatio`         | Crop to specified aspect ratio.
+|               | `RCropRatio`        | Crop random window of specified aspect ratio.
 | *Utilities:*  | `NoOp`              | Identity function. Pass image along unchanged.
 |               | `CacheImage`        | Buffer the current image into (preallocated) memory.
 |               | `Either`            | Apply one of the given operations at random.

--- a/docs/usersguide/operations.rst
+++ b/docs/usersguide/operations.rst
@@ -19,6 +19,7 @@ functionality.
 | Scaling and Resizing  | :class:`Scale` :class:`Zoom` :class:`Resize`                               |
 +-----------------------+----------------------------------------------------------------------------+
 | Cropping              | :class:`Crop` :class:`CropNative` :class:`CropSize` :class:`CropRatio`     |
+|                       | :class:`RCropRatio`                                                        |
 +-----------------------+----------------------------------------------------------------------------+
 | Utility Operations    | :class:`NoOp` :class:`CacheImage` :class:`Either`                          |
 +-----------------------+----------------------------------------------------------------------------+
@@ -503,6 +504,30 @@ Cropping
 +============================================================================================================+============================================================================================================+
 | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/testpattern_small.png    | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/CropRatio.png |
 +------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------+
+
+.. class:: RCropRatio
+
+   Crops out the biggest possible area at some random position of
+   the given image, such that the output image satisfies the
+   specified aspect ratio (i.e. width divided by height).
+
+   For example the operation ``RCropRatio(1)`` would denote a
+   crop for the biggest possible square. If there is more than
+   one such square, then one will be selected at random.
+
+.. code-block:: jlcon
+
+   julia> RCropRatio(1)
+   Crop random window with 1:1 aspect ratio
+
+   julia> CropRatio(2.5)
+   Crop random window with 5:2 aspect ratio
+
++-------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
+| Input                                                                                                       | Sampled outputs for ``RCropRatio(1)``                                                                       |
++=============================================================================================================+=============================================================================================================+
+| .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/testpattern_small.png     | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/RCropRatio.gif |
++-------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+
 
 Resizing
 ***********

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -32,6 +32,7 @@ export
     CropNative,
     CropSize,
     CropRatio,
+    RCropRatio,
 
     Resize,
 


### PR DESCRIPTION
`RCropRatio` randomly crops out a maximal rectangle that satisfies the given aspect ratio (i.e. width divided by height). In contrast to `CropRatio` this window need not be around the image center.

`CropRatio(1)` | `RCropRatio(1)`
---------------|-------------------
![CropRatio](https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/CropRatio.png) | ![RCropRatio](https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/RCropRatio.gif)