### PR TITLE
Tidy up design by introduction of `supports_affineview`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 # v0.2.0
 
-Dropped 0.5 support
+- `Either` can now lazily combine affine operations with operations
+  such as `Crop`, `Zoom`, and `Resize`. This is because a new kind
+  of support was introduced called `Augmentor.supports_affineview`,
+  which is true if an operation can represent itself as a `SubArray`
+  of a `InvWarpedView`.
+
+- Dropped 0.5 support
 
 # v0.1.0
 

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -78,7 +78,7 @@ include("distortedview.jl")
 include("operations/distortion.jl")
 
 include("pipeline.jl")
-include("compile.jl")
+include("codegen.jl")
 include("augment.jl")
 
 end # module

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -46,5 +46,5 @@ end
 end
 
 @generated function _augment(img, pipeline::Vararg{Operation})
-    Expr(:block, Expr(:meta, :inline), build_pipeline(:img, pipeline))
+    Expr(:block, Expr(:meta, :inline), augment_impl(:img, pipeline))
 end

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -1,4 +1,11 @@
-@inline function seek_connected(f, N, head, tail::Tuple)
+"""
+    seek_connected(f, N::Int, head::DataType, tail::Tuple) -> (N, seq)
+
+Recursively scan a tuple of `DataType` (split into its `head` and
+`tail`) to compute the uninterrupted sequence `seq` of adjacent
+operations (and its length `N`) where the predicate `f` is true.
+"""
+@inline function seek_connected(f, N::Int, head::Type{<:Operation}, tail::Tuple)
     if f(head)
         seek_connected(f, N+1, first(tail), Base.tail(tail))
     else
@@ -6,7 +13,7 @@
     end
 end
 
-@inline function seek_connected(f, N, head, tail::Tuple{})
+@inline function seek_connected(f, N::Int, head::Type{<:Operation}, tail::Tuple{})
     if f(head)
         N+1, ()
     else
@@ -16,18 +23,20 @@ end
 
 # --------------------------------------------------------------------
 
-@inline supports_lazy(head, tail::Tuple) = supports_lazy(head) && supports_lazy(first(tail))
-@inline supports_lazy(head, tail::Tuple{}) = false
-@inline uses_affinemap(head, tail::Tuple) = uses_affinemap(head) && uses_affinemap(first(tail))
-@inline uses_affinemap(head, tail::Tuple{}) = false
+@inline supports_lazy(head::Type{<:Operation}, tail::Tuple{}) = false
+@inline supports_lazy(head::Type{<:Operation}, tail::Tuple) =
+    supports_lazy(head) && supports_lazy(first(tail))
+@inline uses_affinemap(head::Type{<:Operation}, tail::Tuple{}) = false
+@inline uses_affinemap(head::Type{<:Operation}, tail::Tuple) =
+    uses_affinemap(head) && uses_affinemap(first(tail))
 
 # --------------------------------------------------------------------
 
-@inline function build_pipeline(var_offset::Int, op_offset::Int, pipeline::Tuple)
+function build_pipeline(var_offset::Int, op_offset::Int, pipeline::Tuple)
     build_pipeline(var_offset, op_offset, first(pipeline), Base.tail(pipeline))
 end
 
-@inline function build_pipeline(var_offset::Int, op_offset::Int, pipeline::Tuple{})
+function build_pipeline(var_offset::Int, op_offset::Int, pipeline::Tuple{})
     :($(Symbol(:img_, var_offset)))
 end
 
@@ -40,12 +49,12 @@ function build_pipeline(var_offset::Int, op_offset::Int, head, tail::NTuple{N,Da
         num_lazy, rest_lazy = seek_connected(supports_lazy, 0, head, tail)
         if num_special >= num_affine
             quote
-                $var_out = forcelazy($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_lazy-1)...)), $var_in)
+                $var_out = unroll_applylazy($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_lazy-1)...)), $var_in)
                 $(build_pipeline(var_offset+1, op_offset+num_lazy, rest_lazy))
             end
         else
             quote
-                $var_out = forceaffine($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_affine-1)...)), $var_in)
+                $var_out = unroll_applyaffine($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_affine-1)...)), $var_in)
                 $(build_pipeline(var_offset+1, op_offset+num_affine, rest_affine))
             end
         end
@@ -57,7 +66,7 @@ function build_pipeline(var_offset::Int, op_offset::Int, head, tail::NTuple{N,Da
             end
         else # use lazy because there is no special eager implementation
             quote
-                $var_out = forcelazy(pipeline[$op_offset], $var_in)
+                $var_out = unroll_applylazy(pipeline[$op_offset], $var_in)
                 $(build_pipeline(var_offset+1, op_offset+1, tail))
             end
         end
@@ -73,7 +82,27 @@ end
 
 # --------------------------------------------------------------------
 
-# just for user inspection to see how it works. not used internally
+# The following two methods are just for user inspection and debugging
+# purposes as they show what kind of code the pipeline generates.
+# They are not called internally by the package itself.
+#
+# Example:
+#
+#   julia> Augmentor.build_pipeline(Rotate(45) |> Scale(0.9) |> CacheImage() |> FlipX() |> FlipY())
+#   quote
+#       img_1 = input_image
+#       begin
+#           img_2 = unroll_applyaffine((pipeline[1], pipeline[2]), img_1)
+#           begin
+#               img_3 = applyeager(pipeline[3], img_2)
+#               begin
+#                   img_4 = unroll_applylazy((pipeline[4], pipeline[5]), img_3)
+#                   img_4
+#               end
+#           end
+#       end
+#   end
+
 function build_pipeline(pipeline::AbstractPipeline)
     build_pipeline(:input_image, map(typeof, operations(pipeline)))
 end

--- a/src/operation.jl
+++ b/src/operation.jl
@@ -103,10 +103,13 @@ function applyaffine_common(op::AffineOperation, img)
     invwarpedview(img, toaffinemap_common(op, img))
 end
 
-function applyaffineview_common(op::Operation, img)
+function applyaffineview_common(op::AffineOperation, img)
     wv = applyaffine_common(op, img)
     direct_view(wv, indices(wv))
 end
+
+# We trust that non-affine operations use SArray-only AffineMap.
+applyaffineview_common(op::Operation, img) = applyaffineview(op, img)
 
 # --------------------------------------------------------------------
 # Functions to unroll sequences of Operation. These are called by

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -55,6 +55,8 @@ immutable CacheImage <: ImageOperation end
 
 applyeager(op::CacheImage, img::Array) = img
 applyeager(op::CacheImage, img::OffsetArray) = img
+applyeager(op::CacheImage, img::SubArray) = copy(img)
+applyeager(op::CacheImage, img::InvWarpedView) = copy(img)
 applyeager(op::CacheImage, img) = collect(img)
 
 function showconstruction(io::IO, op::CacheImage)

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -72,6 +72,11 @@ end
 
 # --------------------------------------------------------------------
 
+"""
+    CacheImageInto <: Augmentor.ImageOperation
+
+see [`CacheImage`](@ref)
+"""
 immutable CacheImageInto{T<:AbstractArray} <: ImageOperation
     buffer::T
 end

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -55,7 +55,7 @@ immutable CacheImage <: ImageOperation end
 
 applyeager(op::CacheImage, img::Array) = img
 applyeager(op::CacheImage, img::OffsetArray) = img
-applyeager(op::CacheImage, img) = copy(img) # FIXME: collect
+applyeager(op::CacheImage, img) = collect(img)
 
 function showconstruction(io::IO, op::CacheImage)
     print(io, typeof(op).name.name, "()")
@@ -85,7 +85,7 @@ CacheImage(buffer::AbstractArray) = CacheImageInto(buffer)
 @inline supports_lazy(::Type{<:CacheImageInto}) = true
 
 @inline match_idx(buffer::AbstractArray, inds::Tuple) = buffer
-@inline match_idx{N}(buffer::Array, inds::NTuple{N,UnitRange}) =
+@inline match_idx(buffer::Array, inds::NTuple{N,UnitRange}) where {N} =
     OffsetArray(buffer, inds)
 
 applyeager(op::CacheImageInto, img) = applylazy(op, img)

--- a/src/operations/either.jl
+++ b/src/operations/either.jl
@@ -156,6 +156,17 @@ end
 @inline isinvwarpedview(::Type{<:InvWarpedView}) = true
 @inline isinvwarpedview(::Type) = false
 
+function toaffinemap(op::Either, img)
+    supports_affine(typeof(op)) || throw(MethodError(toaffinemap, (op, img)))
+    p = rand()
+    for (i, p_i) in enumerate(op.cum_chances)
+        if p <= p_i
+            return toaffinemap_common(op.operations[i], img)
+        end
+    end
+    error("unreachable code reached")
+end
+
 # Sample a random operation and pass the function call along.
 # Note: "applyaffine" needs to map to "applyaffine_common" for
 #   type stability, because otherwise the concrete type of the

--- a/src/operations/flip.jl
+++ b/src/operations/flip.jl
@@ -56,7 +56,7 @@ FlipX(p::Number) = Either(FlipX(), p)
 
 @inline supports_stepview(::Type{FlipX}) = true
 
-toaffine(::FlipX, img::AbstractMatrix) = recenter(@SMatrix([1. 0; 0 -1.]), center(img))
+toaffinemap(::FlipX, img::AbstractMatrix) = recenter(@SMatrix([1. 0; 0 -1.]), center(img))
 # Base.flipdim not type-stable for AbstractArray's
 applyeager(::FlipX, img::Array) = plain_array(flipdim(img,2))
 applyeager(op::FlipX, img::AbstractArray) = plain_array(applystepview(op, img))
@@ -138,7 +138,7 @@ FlipY(p::Number) = Either(FlipY(), p)
 
 @inline supports_stepview(::Type{FlipY}) = true
 
-toaffine(::FlipY, img::AbstractMatrix) = recenter(@SMatrix([-1. 0; 0 1.]), center(img))
+toaffinemap(::FlipY, img::AbstractMatrix) = recenter(@SMatrix([-1. 0; 0 1.]), center(img))
 # Base.flipdim not type-stable for AbstractArray's
 applyeager(::FlipY, img::Array) = plain_array(flipdim(img,1))
 applyeager(op::FlipY, img::AbstractArray) = plain_array(applystepview(op, img))

--- a/src/operations/noop.jl
+++ b/src/operations/noop.jl
@@ -14,7 +14,7 @@ immutable NoOp <: AffineOperation end
 @inline supports_view(::Type{NoOp}) = true
 
 # TODO: implement method for n-dim arrays
-toaffine(::NoOp, img::AbstractMatrix) = AffineMap(@SMatrix([1. 0; 0 1.]), @SVector([0.,0.]))
+toaffinemap(::NoOp, img::AbstractMatrix) = AffineMap(@SMatrix([1. 0; 0 1.]), @SVector([0.,0.]))
 applyeager(::NoOp, img) = plain_array(img)
 applylazy(::NoOp, img) = img
 

--- a/src/operations/resize.jl
+++ b/src/operations/resize.jl
@@ -54,7 +54,7 @@ Resize(size::NTuple{N,Int}) where {N} = Resize{N}(size)
 Resize(size::Int...) = Resize(size)
 Resize(; width=64, height=64) = Resize((height,width))
 
-@inline supports_affine(::Type{<:Resize}) = true
+@inline supports_affineview(::Type{<:Resize}) = true
 
 function toaffinemap(op::Resize{2}, img::AbstractMatrix)
     # emulate behaviour of ImageTransformations.imresize!
@@ -69,14 +69,14 @@ end
 applyeager(op::Resize, img) = plain_array(imresize(img, op.size))
 
 function applylazy(op::Resize, img)
-    applyaffine(op, prepareaffine(img))
+    applyaffineview(op, prepareaffine(img))
 end
 
 function padrange(range::AbstractUnitRange, pad)
     first(range)-pad:last(range)+pad
 end
 
-function applyaffine(op::Resize{N}, img::AbstractArray{T,N}) where {T,N}
+function applyaffineview(op::Resize{N}, img::AbstractArray{T,N}) where {T,N}
     Rin, Rout = CartesianRange(indices(img)), CartesianRange(op.size)
     sf = map(/, (last(Rout)-first(Rout)+1).I, (last(Rin)-first(Rin)+1).I)
     # We have to extrapolate if the image is upscaled,

--- a/src/operations/resize.jl
+++ b/src/operations/resize.jl
@@ -56,7 +56,7 @@ Resize(; width=64, height=64) = Resize((height,width))
 
 @inline supports_affine(::Type{<:Resize}) = true
 
-function toaffine(op::Resize{2}, img::AbstractMatrix)
+function toaffinemap(op::Resize{2}, img::AbstractMatrix)
     # emulate behaviour of ImageTransformations.imresize!
     Rin  = CartesianRange(indices(img))
     sf = map(/, op.size, (last(Rin)-first(Rin)+1).I)
@@ -81,7 +81,7 @@ function applyaffine(op::Resize{N}, img::AbstractArray{T,N}) where {T,N}
     sf = map(/, (last(Rout)-first(Rout)+1).I, (last(Rin)-first(Rin)+1).I)
     # We have to extrapolate if the image is upscaled,
     # otherwise the original border will only cause a single pixel
-    tinv = toaffine(op, img)
+    tinv = toaffinemap(op, img)
     inds = ImageTransformations.autorange(img, tinv)
     pad_inds = map((s,r)-> s>=1 ? padrange(r,ceil(Int,s/2)) : r, sf, inds)
     wv = invwarpedview(img, tinv, pad_inds)

--- a/src/operations/rotation.jl
+++ b/src/operations/rotation.jl
@@ -59,7 +59,7 @@ Rotate90(p::Number) = Either(Rotate90(), p)
 
 @inline supports_permute(::Type{Rotate90}) = true
 
-toaffine(::Rotate90, img::AbstractMatrix) = recenter(RotMatrix(pi/2), center(img))
+toaffinemap(::Rotate90, img::AbstractMatrix) = recenter(RotMatrix(pi/2), center(img))
 applyeager(::Rotate90, img::AbstractMatrix) = plain_array(rotl90(img))
 applylazy_fallback(op::Rotate90, img::AbstractMatrix) = applypermute(op, img)
 
@@ -142,7 +142,7 @@ Rotate180(p::Number) = Either(Rotate180(), p)
 
 @inline supports_stepview(::Type{Rotate180}) = true
 
-toaffine(::Rotate180, img::AbstractMatrix) = recenter(RotMatrix(pi), center(img))
+toaffinemap(::Rotate180, img::AbstractMatrix) = recenter(RotMatrix(pi), center(img))
 applyeager(::Rotate180, img::AbstractMatrix) = plain_array(rot180(img))
 applylazy_fallback(op::Rotate180, img::AbstractMatrix) = applystepview(op, img)
 
@@ -213,7 +213,7 @@ Rotate270(p::Number) = Either(Rotate270(), p)
 
 @inline supports_permute(::Type{Rotate270}) = true
 
-toaffine(::Rotate270, img::AbstractMatrix) = recenter(RotMatrix(-pi/2), center(img))
+toaffinemap(::Rotate270, img::AbstractMatrix) = recenter(RotMatrix(-pi/2), center(img))
 applyeager(::Rotate270, img::AbstractMatrix) = plain_array(rotr90(img))
 applylazy_fallback(op::Rotate270, img::AbstractMatrix) = applypermute(op, img)
 
@@ -320,7 +320,7 @@ Rotate(degree::Real) = Rotate(degree:degree)
 
 @inline supports_eager(::Type{<:Rotate}) = false
 
-function toaffine(op::Rotate, img::AbstractMatrix)
+function toaffinemap(op::Rotate, img::AbstractMatrix)
     recenter(RotMatrix(deg2rad(Float64(rand(op.degree)))), center(img))
 end
 

--- a/src/operations/scale.jl
+++ b/src/operations/scale.jl
@@ -85,7 +85,7 @@ end
 
 @inline supports_eager(::Type{<:Scale}) = false
 
-function toaffine(op::Scale{2}, img::AbstractMatrix)
+function toaffinemap(op::Scale{2}, img::AbstractMatrix)
     idx = rand(1:length(op.factors[1]))
     @inbounds tfm = recenter(@SMatrix([Float64(op.factors[1][idx]) 0.; 0. Float64(op.factors[2][idx])]), center(img))
     tfm

--- a/src/operations/shear.jl
+++ b/src/operations/shear.jl
@@ -62,7 +62,7 @@ ShearX(degree::Real) = ShearX(degree:degree)
 
 @inline supports_eager(::Type{<:ShearX}) = false
 
-function toaffine(op::ShearX, img::AbstractMatrix)
+function toaffinemap(op::ShearX, img::AbstractMatrix)
     angle = deg2rad(Float64(rand(op.degree)))
     recenter(@SMatrix([1. 0.; tan(-angle) 1.]), center(img))
 end
@@ -146,7 +146,7 @@ ShearY(degree::Real) = ShearY(degree:degree)
 
 @inline supports_eager(::Type{<:ShearY}) = false
 
-function toaffine(op::ShearY, img::AbstractMatrix)
+function toaffinemap(op::ShearY, img::AbstractMatrix)
     angle = deg2rad(Float64(rand(op.degree)))
     recenter(@SMatrix([1. tan(-angle); 0. 1.]), center(img))
 end

--- a/src/operations/zoom.jl
+++ b/src/operations/zoom.jl
@@ -87,26 +87,26 @@ function (::Type{Zoom{N}})(factors::NTuple{N,Any}) where N
     Zoom(map(_vectorize, factors))
 end
 
-@inline supports_affine(::Type{<:Zoom}) = true
+@inline supports_affineview(::Type{<:Zoom}) = true
 @inline supports_eager(::Type{<:Zoom}) = false
 
-function toaffine(op::Zoom{2}, img::AbstractMatrix)
+function toaffinemap(op::Zoom{2}, img::AbstractMatrix)
     idx = rand(1:length(op.factors[1]))
     @inbounds tfm = recenter(@SMatrix([Float64(op.factors[1][idx]) 0.; 0. Float64(op.factors[2][idx])]), center(img))
     tfm
 end
 
 function applylazy(op::Zoom, img)
-    applyaffine(op, prepareaffine(img))
+    applyaffineview(op, prepareaffine(img))
 end
 
-function applyaffine(op::Zoom{N}, img::AbstractArray{T,N}) where {T,N}
-    wv = invwarpedview(img, toaffine(op, img), indices(img))
+function applyaffineview(op::Zoom{N}, img::AbstractArray{T,N}) where {T,N}
+    wv = invwarpedview(img, toaffinemap(op, img), indices(img))
     direct_view(wv, indices(img))
 end
 
-function applyaffine(op::Zoom{N}, v::SubArray{T,N,<:InvWarpedView}) where {T,N}
-    tinv = toaffine(op, v)
+function applyaffineview(op::Zoom{N}, v::SubArray{T,N,<:InvWarpedView}) where {T,N}
+    tinv = toaffinemap(op, v)
     img = parent(v)
     nidx = ImageTransformations.autorange(img, tinv)
     wv = InvWarpedView(img, tinv, map(unionrange, nidx, indices(img)))

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -16,6 +16,7 @@ ImmutablePipeline(ops::Vararg{Operation,N}) where {N} = ImmutablePipeline{N}(ops
 @inline operations(p::ImmutablePipeline) = p.operations
 @inline operations(tup::NTuple{N,Operation}) where {N} = tup
 
+# Allow specifying pipelines using the "op1 |> op2 |> op3" syntax.
 Base.:(|>)(op1::Operation, op2::Operation) =
     ImmutablePipeline(op1, op2)
 Base.:(|>)(p1::ImmutablePipeline, op2::Operation) =

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,15 +39,15 @@ end
     I
 end
 
-@inline function indirect_indices(O::NTuple{N,AbstractUnitRange}, I::NTuple{N,AbstractUnitRange}) where N
+function indirect_indices(O::NTuple{N,AbstractUnitRange}, I::NTuple{N,AbstractUnitRange}) where N
     map((i1,i2) -> IdentityRange(UnitRange(i1)[i2]), O, I)
 end
 
-@inline function indirect_indices(O::NTuple{N,AbstractUnitRange}, I::NTuple{N,StepRange}) where N
+function indirect_indices(O::NTuple{N,AbstractUnitRange}, I::NTuple{N,StepRange}) where N
     map((i1,i2) -> UnitRange(i1)[i2], O, I)
 end
 
-@inline function indirect_indices(O::NTuple{N,StepRange}, I::NTuple{N,Range}) where N
+function indirect_indices(O::NTuple{N,StepRange}, I::NTuple{N,Range}) where N
     map((i1,i2) -> i1[i2], O, I)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -5,9 +5,8 @@ Load and return the provided 300x400 test image.
 
 The returned image was specifically designed to be informative
 about the effects of the applied augmentation operations. It is
-thus well suited to prototype an augmentation pipeline, because
-it makes it easy to see what kind of effects one can achieve with
-it.
+thus well suited to prototype an augmentation pipeline, because it
+makes it easy to see what kind of effects one can achieve with it.
 """
 testpattern() = load(joinpath(dirname(@__FILE__()), "..", "resources", "testpattern.png"))
 

--- a/test/operations/tst_cache.jl
+++ b/test/operations/tst_cache.jl
@@ -18,18 +18,20 @@
     o = OffsetArray(square, (-1,2))
     @test @inferred(Augmentor.applyeager(CacheImage(),o)) === o
 
-    @test @inferred(Augmentor.supports_eager(CacheImage)) === true
-    @test @inferred(Augmentor.supports_lazy(CacheImage)) === false
-    @test @inferred(Augmentor.supports_view(CacheImage)) === false
-    @test @inferred(Augmentor.supports_stepview(CacheImage)) === false
-    @test @inferred(Augmentor.supports_permute(CacheImage)) === false
-    @test @inferred(Augmentor.supports_affine(CacheImage)) === false
+    @test Augmentor.supports_eager(CacheImage) === true
+    @test Augmentor.supports_lazy(CacheImage) === false
+    @test Augmentor.supports_view(CacheImage) === false
+    @test Augmentor.supports_stepview(CacheImage) === false
+    @test Augmentor.supports_permute(CacheImage) === false
+    @test Augmentor.supports_affine(CacheImage) === false
+    @test Augmentor.supports_affineview(CacheImage) === false
 
     @test_throws MethodError Augmentor.applylazy(CacheImage(), v)
     @test_throws MethodError Augmentor.applyview(CacheImage(), v)
     @test_throws MethodError Augmentor.applystepview(CacheImage(), v)
     @test_throws MethodError Augmentor.applypermute(CacheImage(), v)
     @test_throws MethodError Augmentor.applyaffine(CacheImage(), v)
+    @test_throws MethodError Augmentor.applyaffineview(CacheImage(), v)
 end
 
 # --------------------------------------------------------------------
@@ -73,15 +75,17 @@ end
 
     @test_throws BoundsError Augmentor.applyeager(op, camera)
 
-    @test @inferred(Augmentor.supports_eager(Augmentor.CacheImageInto)) === true
-    @test @inferred(Augmentor.supports_lazy(Augmentor.CacheImageInto)) === true
-    @test @inferred(Augmentor.supports_view(Augmentor.CacheImageInto)) === false
-    @test @inferred(Augmentor.supports_stepview(Augmentor.CacheImageInto)) === false
-    @test @inferred(Augmentor.supports_permute(Augmentor.CacheImageInto)) === false
-    @test @inferred(Augmentor.supports_affine(Augmentor.CacheImageInto)) === false
+    @test Augmentor.supports_eager(Augmentor.CacheImageInto) === true
+    @test Augmentor.supports_lazy(Augmentor.CacheImageInto) === true
+    @test Augmentor.supports_view(Augmentor.CacheImageInto) === false
+    @test Augmentor.supports_stepview(Augmentor.CacheImageInto) === false
+    @test Augmentor.supports_permute(Augmentor.CacheImageInto) === false
+    @test Augmentor.supports_affine(Augmentor.CacheImageInto) === false
+    @test Augmentor.supports_affineview(Augmentor.CacheImageInto) === false
 
     @test_throws MethodError Augmentor.applyview(CacheImage(buf), v)
     @test_throws MethodError Augmentor.applystepview(CacheImage(buf), v)
     @test_throws MethodError Augmentor.applypermute(CacheImage(buf), v)
     @test_throws MethodError Augmentor.applyaffine(CacheImage(buf), v)
+    @test_throws MethodError Augmentor.applyaffineview(CacheImage(buf), v)
 end

--- a/test/operations/tst_channels.jl
+++ b/test/operations/tst_channels.jl
@@ -10,7 +10,7 @@
         @test str_showcompact(SplitChannels()) == "Split colorant into its color channels"
     end
     @testset "eager" begin
-        @test @inferred(Augmentor.supports_eager(SplitChannels)) === false
+        @test Augmentor.supports_eager(SplitChannels) === false
         @test_throws MethodError Augmentor.applyeager(SplitChannels(), rand(2,2))
         for img in (Augmentor.prepareaffine(rect), rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(SplitChannels(), img)) == reshape(rect, 1, 2, 3)
@@ -22,11 +22,13 @@
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(SplitChannels)) === false
-        @test @inferred(Augmentor.supports_affine(SplitChannels)) === false
+        @test Augmentor.supports_affine(SplitChannels) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(SplitChannels) === false
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(SplitChannels)) === true
+        @test Augmentor.supports_lazy(SplitChannels) === true
         @test @inferred(Augmentor.supports_lazy(typeof(SplitChannels()))) === true
         @test_throws MethodError Augmentor.applylazy(SplitChannels(), rand(2,2))
         for img in (Augmentor.prepareaffine(rect), rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
@@ -47,13 +49,13 @@
         end
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(SplitChannels)) === false
+        @test Augmentor.supports_view(SplitChannels) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(SplitChannels)) === false
+        @test Augmentor.supports_stepview(SplitChannels) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(SplitChannels)) === false
+        @test Augmentor.supports_permute(SplitChannels) === false
     end
 end
 
@@ -75,7 +77,7 @@ end
         @test str_showcompact(CombineChannels(Gray)) == "Combine color channels into colorant Gray{Any}"
     end
     @testset "eager" begin
-        @test @inferred(Augmentor.supports_eager(CombineChannels)) === false
+        @test Augmentor.supports_eager(CombineChannels) === false
         @test_throws MethodError Augmentor.applyeager(CombineChannels(RGB), rand(RGB{N0f8},4,4))
         @test_throws MethodError Augmentor.applyeager(CombineChannels(Gray), rand(Gray{N0f8},4,4))
         @test_throws ArgumentError Augmentor.applyeager(CombineChannels(Gray), rand(4,4))
@@ -95,11 +97,13 @@ end
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(CombineChannels)) === false
-        @test @inferred(Augmentor.supports_affine(CombineChannels)) === false
+        @test Augmentor.supports_affine(CombineChannels) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(CombineChannels) === false
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(CombineChannels)) === true
+        @test Augmentor.supports_lazy(CombineChannels) === true
         @test @inferred(Augmentor.supports_lazy(typeof(CombineChannels(Gray)))) === true
         @test_throws MethodError Augmentor.applylazy(CombineChannels(RGB), rand(RGB{N0f8},4,4))
         @test_throws MethodError Augmentor.applylazy(CombineChannels(Gray), rand(Gray{N0f8},4,4))
@@ -124,13 +128,13 @@ end
         end
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(CombineChannels)) === false
+        @test Augmentor.supports_view(CombineChannels) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(CombineChannels)) === false
+        @test Augmentor.supports_stepview(CombineChannels) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(CombineChannels)) === false
+        @test Augmentor.supports_permute(CombineChannels) === false
     end
 end
 
@@ -159,7 +163,7 @@ end
         @test str_showcompact(PermuteDims((3,2,1))) == "Permute dimension order to (3, 2, 1)"
     end
     @testset "eager" begin
-        @test @inferred(Augmentor.supports_eager(PermuteDims)) === true
+        @test Augmentor.supports_eager(PermuteDims) === true
         @test @inferred(Augmentor.supports_eager(typeof(PermuteDims(2,1)))) === true
         for img in (Augmentor.prepareaffine(rect), rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test_throws MethodError Augmentor.applyeager(PermuteDims(3,2,1), img)
@@ -168,11 +172,13 @@ end
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(PermuteDims)) === false
-        @test @inferred(Augmentor.supports_affine(PermuteDims)) === false
+        @test Augmentor.supports_affine(PermuteDims) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(PermuteDims) === false
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(PermuteDims)) === true
+        @test Augmentor.supports_lazy(PermuteDims) === true
         @test @inferred(Augmentor.supports_lazy(typeof(PermuteDims(2,1)))) === true
         for img in (Augmentor.prepareaffine(rect), rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test_throws MethodError Augmentor.applylazy(PermuteDims(3,2,1), img)
@@ -180,13 +186,13 @@ end
         end
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(PermuteDims)) === false
+        @test Augmentor.supports_view(PermuteDims) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(PermuteDims)) === false
+        @test Augmentor.supports_stepview(PermuteDims) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(PermuteDims)) === false
+        @test Augmentor.supports_permute(PermuteDims) === false
     end
 end
 
@@ -216,7 +222,7 @@ end
         @test str_showcompact(Reshape(10)) == "Reshape array to 10-element vector"
     end
     @testset "eager" begin
-        @test @inferred(Augmentor.supports_eager(Reshape)) === false
+        @test Augmentor.supports_eager(Reshape) === false
         @test @inferred(Augmentor.supports_eager(typeof(Reshape(2,1)))) === false
         # FIXME: reintroduce Augmentor.prepareaffine(rect) in 0.6
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
@@ -225,11 +231,13 @@ end
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(Reshape)) === false
-        @test @inferred(Augmentor.supports_affine(Reshape)) === false
+        @test Augmentor.supports_affine(Reshape) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Reshape) === false
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(Reshape)) === true
+        @test Augmentor.supports_lazy(Reshape) === true
         @test @inferred(Augmentor.supports_lazy(typeof(Reshape(2,1)))) === true
         # FIXME: reintroduce Augmentor.prepareaffine(rect) in 0.6
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
@@ -242,12 +250,12 @@ end
         end
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(Reshape)) === false
+        @test Augmentor.supports_view(Reshape) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(Reshape)) === false
+        @test Augmentor.supports_stepview(Reshape) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(Reshape)) === false
+        @test Augmentor.supports_permute(Reshape) === false
     end
 end

--- a/test/operations/tst_crop.jl
+++ b/test/operations/tst_crop.jl
@@ -28,10 +28,12 @@
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(Crop) === false
-        @test Augmentor.supports_affine(Crop) === true
-        @test_throws MethodError Augmentor.applyaffine(Crop(1:2,2:3), nothing)
-        @test @inferred(Augmentor.applyaffine(Crop(1:2,2:3), rect)) === view(rect, IdentityRange(1:2), IdentityRange(2:3))
+        @test Augmentor.supports_affine(Crop) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Crop) === true
+        @test_throws MethodError Augmentor.applyaffineview(Crop(1:2,2:3), nothing)
+        @test @inferred(Augmentor.applyaffineview(Crop(1:2,2:3), rect)) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(2:3))
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(Crop) === true
@@ -85,10 +87,12 @@ end
         @test typeof(Augmentor.applyeager(CropNative(-1:0,1:2), img)) <: Array
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(CropNative) === false
-        @test Augmentor.supports_affine(CropNative) === true
-        @test_throws MethodError Augmentor.applyaffine(CropNative(1:2,2:3), nothing)
-        @test @inferred(Augmentor.applyaffine(CropNative(1:2,2:3), rect)) === view(rect, IdentityRange(1:2), IdentityRange(2:3))
+        @test Augmentor.supports_affine(CropNative) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(CropNative) === true
+        @test_throws MethodError Augmentor.applyaffineview(CropNative(1:2,2:3), nothing)
+        @test @inferred(Augmentor.applyaffineview(CropNative(1:2,2:3), rect)) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(2:3))
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(CropNative) === true
@@ -149,11 +153,13 @@ end
         @test @inferred(Augmentor.applyeager(CropSize(4,4), square2)) == square2
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(CropSize) === false
-        @test Augmentor.supports_affine(CropSize) === true
-        @test_throws MethodError Augmentor.applyaffine(CropSize(1:2,2:3), nothing)
-        @test @inferred(Augmentor.applyaffine(CropSize(2,3), rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
-        @test @inferred(Augmentor.applyaffine(CropSize(2,2), square2)) === view(square2, IdentityRange(2:3), IdentityRange(2:3))
+        @test Augmentor.supports_affine(CropSize) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(CropSize) === true
+        @test_throws MethodError Augmentor.applyaffineview(CropSize(1:2,2:3), nothing)
+        @test @inferred(Augmentor.applyaffineview(CropSize(2,3), rect)) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:3))
+        @test @inferred(Augmentor.applyaffineview(CropSize(2,2), square2)) == view(Augmentor.prepareaffine(square2), IdentityRange(2:3), IdentityRange(2:3))
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(CropSize) === true
@@ -219,12 +225,14 @@ end
         @test @inferred(Augmentor.applyeager(CropRatio(1), square2)) == square2
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(CropRatio) === false
-        @test Augmentor.supports_affine(CropRatio) === true
-        @test_throws MethodError Augmentor.applyaffine(CropRatio(1), nothing)
-        @test @inferred(Augmentor.applyaffine(CropRatio(1), rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:2))
-        @test @inferred(Augmentor.applyaffine(CropRatio(2), square2)) === view(square2, IdentityRange(2:3), IdentityRange(1:4))
-        @test @inferred(Augmentor.applyaffine(CropRatio(.5), square2)) === view(square2, IdentityRange(1:4), IdentityRange(2:3))
+        @test Augmentor.supports_affine(CropRatio) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(CropRatio) === true
+        @test_throws MethodError Augmentor.applyaffineview(CropRatio(1), nothing)
+        @test @inferred(Augmentor.applyaffineview(CropRatio(1), rect)) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:2))
+        @test @inferred(Augmentor.applyaffineview(CropRatio(2), square2)) == view(Augmentor.prepareaffine(square2), IdentityRange(2:3), IdentityRange(1:4))
+        @test @inferred(Augmentor.applyaffineview(CropRatio(.5), square2)) == view(Augmentor.prepareaffine(square2), IdentityRange(1:4), IdentityRange(2:3))
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(CropRatio) === true
@@ -294,20 +302,22 @@ end
         @test out == rect[1:2,1:2] || out == rect[1:2,2:3]
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(RCropRatio) === false
-        @test Augmentor.supports_affine(RCropRatio) === true
-        @test_throws MethodError Augmentor.applyaffine(RCropRatio(1), nothing)
+        @test Augmentor.supports_affine(RCropRatio) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(RCropRatio) === true
+        @test_throws MethodError Augmentor.applyaffineview(RCropRatio(1), nothing)
         # preserve aspect ratio (i.e. not random)
-        @test @inferred(Augmentor.applyaffine(RCropRatio(3/2), rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
-        @test @inferred(Augmentor.applyaffine(RCropRatio(1), square)) === view(square, IdentityRange(1:3), IdentityRange(1:3))
-        @test @inferred(Augmentor.applyaffine(RCropRatio(1), square2)) === view(square2, IdentityRange(1:4), IdentityRange(1:4))
+        @test @inferred(Augmentor.applyaffineview(RCropRatio(3/2), rect)) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:3))
+        @test @inferred(Augmentor.applyaffineview(RCropRatio(1), square)) == view(Augmentor.prepareaffine(square), IdentityRange(1:3), IdentityRange(1:3))
+        @test @inferred(Augmentor.applyaffineview(RCropRatio(1), square2)) == view(Augmentor.prepareaffine(square2), IdentityRange(1:4), IdentityRange(1:4))
         # randomly placed
-        out = @inferred Augmentor.applyaffine(RCropRatio(1), rect)
-        @test out === view(rect, IdentityRange(1:2), IdentityRange(1:2)) || out === view(rect, IdentityRange(1:2), IdentityRange(2:3))
-        out = @inferred Augmentor.applyaffine(RCropRatio(2/3), square)
-        @test out === view(square, IdentityRange(1:3), IdentityRange(1:2)) || out === view(square, IdentityRange(1:3), IdentityRange(2:3))
-        out = @inferred Augmentor.applyaffine(RCropRatio(3/2), square)
-        @test out === view(square, IdentityRange(1:2), IdentityRange(1:3)) || out === view(square, IdentityRange(2:3), IdentityRange(1:3))
+        out = @inferred Augmentor.applyaffineview(RCropRatio(1), rect)
+        @test out == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:2)) || out == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(2:3))
+        out = @inferred Augmentor.applyaffineview(RCropRatio(2/3), square)
+        @test out == view(Augmentor.prepareaffine(square), IdentityRange(1:3), IdentityRange(1:2)) || out == view(Augmentor.prepareaffine(square), IdentityRange(1:3), IdentityRange(2:3))
+        out = @inferred Augmentor.applyaffineview(RCropRatio(3/2), square)
+        @test out == view(Augmentor.prepareaffine(square), IdentityRange(1:2), IdentityRange(1:3)) || out == view(Augmentor.prepareaffine(square), IdentityRange(2:3), IdentityRange(1:3))
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(RCropRatio) === true

--- a/test/operations/tst_distortions.jl
+++ b/test/operations/tst_distortions.jl
@@ -85,7 +85,7 @@
         end
     end
     @testset "eager" begin
-        @test @inferred(Augmentor.supports_eager(ElasticDistortion)) === false
+        @test Augmentor.supports_eager(ElasticDistortion) === false
         for img in (square, OffsetArray(square, 0, 0), view(square, IdentityRange(1:3), IdentityRange(1:3)))
             dv = @inferred Augmentor.applyeager(ElasticDistortion(4,4), img)
             # TODO: better tests
@@ -94,10 +94,13 @@
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.supports_affine(ElasticDistortion)) === false
+        @test Augmentor.supports_affine(ElasticDistortion) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(ElasticDistortion) === false
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(ElasticDistortion)) === true
+        @test Augmentor.supports_lazy(ElasticDistortion) === true
         for img in (square, OffsetArray(square, 0, 0), view(square, IdentityRange(1:3), IdentityRange(1:3)))
             dv = @inferred Augmentor.applylazy(ElasticDistortion(4,4), img)
             # TODO: better tests
@@ -107,12 +110,12 @@
         end
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(ElasticDistortion)) === false
+        @test Augmentor.supports_view(ElasticDistortion) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(ElasticDistortion)) === false
+        @test Augmentor.supports_stepview(ElasticDistortion) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(ElasticDistortion)) === false
+        @test Augmentor.supports_permute(ElasticDistortion) === false
     end
 end

--- a/test/operations/tst_either.jl
+++ b/test/operations/tst_either.jl
@@ -88,15 +88,15 @@ end
     @test_throws MethodError Augmentor.applyeager(Either(Rotate90(),NoOp()), nothing)
     for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
         op = @inferred Either((Rotate90(),Rotate270()), (1,0))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == rotl90(rect)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),Rotate270(),Crop(1:2,2:3)), (0,1,0))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == rotr90(rect)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),Rotate270(),NoOp()), (0,0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         if typeof(img) <: SubArray
             @test @inferred(Augmentor.applyeager(op, img)) == rect
             @test typeof(Augmentor.applyeager(op, img)) <: Array
@@ -104,35 +104,34 @@ end
             @test @inferred(Augmentor.applyeager(op, img)) === rect
         end
         op = @inferred Either((Rotate90(),Rotate270(),Crop(1:2,2:3)), (0,0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == rect[1:2,2:3]
-        @test_throws MethodError Augmentor.applylazy(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, rect)
         @test_throws MethodError Augmentor.applyview(op, rect)
         @test_throws MethodError Augmentor.applystepview(op, rect)
         @test_throws MethodError Augmentor.applypermute(op, rect)
         op = @inferred Either((Rotate90(),Zoom(.8)), (1,0))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == rotl90(rect)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),FlipX()), (1,0))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == rotl90(rect)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),FlipX()), (0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == flipdim(rect,2)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),FlipY()), (0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == flipdim(rect,1)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Rotate90(),Resize(5,5)), (0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == imresize(rect,5,5)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
         op = @inferred Either((Crop(1:2,1:2),Resize(5,5)), (0,1))
-        @test @inferred(Augmentor.supports_eager(op)) === true
+        @test Augmentor.supports_eager(op) === true
         @test @inferred(Augmentor.applyeager(op, img)) == imresize(rect,5,5)
         @test typeof(Augmentor.applyeager(op, img)) <: Array
     end
@@ -140,84 +139,84 @@ end
 
 @testset "affine" begin
     let op = @inferred Either((Rotate90(),Rotate(-90)), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotl90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     let op = @inferred Either((Rotate90(),Rotate270()), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === true
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === true
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotl90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     let op = @inferred Either((Rotate180(),FlipX(),FlipY()), (0,1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([1. 0.; 0. -1.], [0,4])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([1. 0.; 0. -1.], [0,4])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == flipdim(square,2)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     let op = @inferred Either((Rotate90(),FlipY()), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([-1. 0.; 0. 1.], [3,0])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([-1. 0.; 0. 1.], [3,0])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == flipdim(square,1)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     let op = @inferred Either((Rotate90(),Rotate270()), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === true
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === true
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotr90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     for op = (@inferred(Rotate90(1)), @inferred(Either((Rotate90(),Scale(0.8)),(1,0))))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applyaffine(op, nothing)
-        @test @inferred(Augmentor.toaffine(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
+        @test @inferred(Augmentor.toaffinemap(op, rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
         wv = @inferred Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotl90(square)
@@ -227,104 +226,154 @@ end
         @test wv2 == rotl90(square)
         @test typeof(wv2) == typeof(wv)
     end
-    let op = @inferred Either((Rotate90(),Rotate270(),Crop(1:2,1:2)))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === false
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
-        @test_throws MethodError Augmentor.toaffine(op, nothing)
-        @test_throws MethodError Augmentor.toaffine(op, rect)
+end
+
+@testset "affineview" begin
+    let op = @inferred Either((Rotate90(),Rotate270(),Crop(1:2,1:2)),(1,0,0))
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
+        @test_throws MethodError Augmentor.toaffinemap(op, nothing)
+        @test_throws MethodError Augmentor.toaffinemap(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
+        wv = @inferred Augmentor.applyaffineview(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == rotl90(square)
+        wv2 = @inferred Augmentor.applylazy(op, square)
+        @test typeof(wv) == typeof(wv2)
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2 == wv
     end
-    let op = @inferred Either((Rotate90(),Rotate270(),CropSize(2,2)))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === false
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
-        @test_throws MethodError Augmentor.toaffine(op, nothing)
-        @test_throws MethodError Augmentor.toaffine(op, rect)
+    let op = @inferred Either((Rotate90(),Rotate270(),CropSize(2,2)),(0,0,1))
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
+        @test_throws MethodError Augmentor.toaffinemap(op, nothing)
+        @test_throws MethodError Augmentor.toaffinemap(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
+        wv = @inferred Augmentor.applyaffineview(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == view(Augmentor.prepareaffine(square), IdentityRange(1:2), IdentityRange(1:2))
+        wv2 = @inferred Augmentor.applylazy(op, square)
+        @test typeof(wv) == typeof(wv2)
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2 == wv
     end
-    let op = @inferred Either((Rotate90(),Zoom(.8)))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === false
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
-        @test_throws MethodError Augmentor.toaffine(op, nothing)
-        @test_throws MethodError Augmentor.toaffine(op, rect)
+    let op = @inferred Either((Rotate90(),Zoom(.8)), (0,1))
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
+        @test_throws MethodError Augmentor.toaffinemap(op, nothing)
+        @test_throws MethodError Augmentor.toaffinemap(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
+        wv = @inferred Augmentor.applyaffineview(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        wv2 = @inferred Augmentor.applylazy(op, square)
+        @test typeof(wv) == typeof(wv2)
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2 == wv
     end
-    let op = @inferred Either((Rotate90(),Resize(2,3)))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === false
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
-        @test_throws MethodError Augmentor.toaffine(op, nothing)
-        @test_throws MethodError Augmentor.toaffine(op, rect)
+    let op = @inferred Either((Rotate90(),Resize(2,3)), (0,1))
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
+        @test_throws MethodError Augmentor.toaffinemap(op, nothing)
+        @test_throws MethodError Augmentor.toaffinemap(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
+        wv = @inferred Augmentor.applyaffineview(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == imresize(square, (2,3))
+        wv2 = @inferred Augmentor.applylazy(op, square)
+        @test typeof(wv) == typeof(wv2)
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2 == wv
     end
-    let op = @inferred Either((Crop(1:2,1:2),Resize(2,3)))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === false
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === false
-        @test_throws MethodError Augmentor.toaffine(op, nothing)
-        @test_throws MethodError Augmentor.toaffine(op, rect)
+    let op = @inferred Either((Crop(1:2,1:2),Resize(2,3)), (1,0))
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === false
+        @test_throws MethodError Augmentor.toaffinemap(op, nothing)
+        @test_throws MethodError Augmentor.toaffinemap(op, rect)
         @test_throws MethodError Augmentor.applyaffine(op, Augmentor.prepareaffine(square))
+        wv = @inferred Augmentor.applyaffineview(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == square[1:2,1:2]
+        wv2 = @inferred Augmentor.applylazy(op, square)
+        @test typeof(wv) == typeof(wv2)
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2 == wv
     end
 end
 
 @testset "view" begin
     let op = @inferred Either((NoOp(),Crop(1:2,2:3)), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === true
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === true
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test @inferred(Augmentor.applyview(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
         @test @inferred(Augmentor.applylazy(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
+        @test @inferred(Augmentor.applyaffineview(op, Augmentor.prepareaffine(rect))) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:3))
     end
     let op = @inferred Either((NoOp(),Crop(1:2,2:3)), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === true
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === true
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test @inferred(Augmentor.applyview(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(2:3))
         @test @inferred(Augmentor.applylazy(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(2:3))
+        @test @inferred(Augmentor.applyaffineview(op, Augmentor.prepareaffine(rect))) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(2:3))
     end
     let op = @inferred Either((Crop(1:2,2:4),CropSize(2,3)), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === true
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === true
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test @inferred(Augmentor.applyview(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
         @test @inferred(Augmentor.applylazy(op, rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
+        @test @inferred(Augmentor.applyaffineview(op, Augmentor.prepareaffine(rect))) == view(Augmentor.prepareaffine(rect), IdentityRange(1:2), IdentityRange(1:3))
     end
 end
 
 @testset "stepview" begin
     let op = @inferred Either((Rotate180(),FlipX()), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -334,12 +383,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((Rotate180(),FlipX()), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -349,12 +398,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((FlipY(),FlipX()), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -364,12 +413,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((Rotate180(),NoOp()), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -379,12 +428,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((Rotate180(),NoOp(),Crop(1:2,2:3)),(0,1,0))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -392,14 +441,19 @@ end
         @test v === view(rect,1:1:2,1:1:3)
         @test v == rect
         @test typeof(v) <: SubArray
+        wv = @inferred Augmentor.applylazy(op, Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == square
     end
     let op = @inferred Either((Rotate180(),NoOp(),Crop(1:2,2:3)),(0,0,1))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -408,12 +462,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((Rotate180(),CropSize(2,3)),(0,1))
-        @test @inferred(Augmentor.isaffine(op)) === false
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === false
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === true
-        @test @inferred(Augmentor.supports_permute(op)) === false
+        @test Augmentor.supports_affine(op) === false
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === true
+        @test Augmentor.supports_permute(op) === false
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applystepview(op, nothing)
         v = @inferred Augmentor.applylazy(op, square)
@@ -425,12 +479,12 @@ end
 
 @testset "permute" begin
     let op = @inferred Either((Rotate90(),Rotate270()), (1,0))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === true
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === true
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applypermute(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)
@@ -440,12 +494,12 @@ end
         @test typeof(v) <: SubArray
     end
     let op = @inferred Either((Rotate90(),Rotate270()), (0,1))
-        @test @inferred(Augmentor.isaffine(op)) === true
-        @test @inferred(Augmentor.supports_lazy(op)) === true
-        @test @inferred(Augmentor.supports_affine(op)) === true
-        @test @inferred(Augmentor.supports_view(op)) === false
-        @test @inferred(Augmentor.supports_stepview(op)) === false
-        @test @inferred(Augmentor.supports_permute(op)) === true
+        @test Augmentor.supports_affine(op) === true
+        @test Augmentor.supports_lazy(op) === true
+        @test Augmentor.supports_affineview(op) === true
+        @test Augmentor.supports_view(op) === false
+        @test Augmentor.supports_stepview(op) === false
+        @test Augmentor.supports_permute(op) === true
         @test_throws MethodError Augmentor.applylazy(op, nothing)
         @test_throws MethodError Augmentor.applypermute(op, nothing)
         v = @inferred Augmentor.applylazy(op, rect)

--- a/test/operations/tst_flip.jl
+++ b/test/operations/tst_flip.jl
@@ -8,24 +8,32 @@
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(FlipX(), nothing)
-        @test @inferred(Augmentor.supports_eager(FlipX)) === true
+        @test Augmentor.supports_eager(FlipX) === true
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(FlipX(), img)) == flipdim(rect,2)
             @test typeof(Augmentor.applyeager(FlipX(), img)) <: Array
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(FlipX)) === true
-        @test @inferred(Augmentor.supports_affine(FlipX)) === true
+        @test Augmentor.supports_affine(FlipX) === true
         @test_throws MethodError Augmentor.applyaffine(FlipX(), nothing)
-        @test @inferred(Augmentor.toaffine(FlipX(), rect)) ≈ AffineMap([1. 0.; 0. -1.], [0.0,4.0])
+        @test @inferred(Augmentor.toaffinemap(FlipX(), rect)) ≈ AffineMap([1. 0.; 0. -1.], [0.0,4.0])
         wv = @inferred Augmentor.applyaffine(FlipX(), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == flipdim(square,2)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(FlipX) === true
+        @test_throws MethodError Augmentor.applyaffineview(FlipX(), nothing)
+        wv = @inferred Augmentor.applyaffineview(FlipX(), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == flipdim(square,2)
+    end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(FlipX)) === true
+        @test Augmentor.supports_lazy(FlipX) === true
         v = @inferred Augmentor.applylazy(FlipX(), rect)
         @test v === view(rect, 1:1:2, 3:-1:1)
         @test v == flipdim(rect,2)
@@ -36,17 +44,17 @@
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(FlipX)) === false
+        @test Augmentor.supports_view(FlipX) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(FlipX)) === true
+        @test Augmentor.supports_stepview(FlipX) === true
         v = @inferred Augmentor.applylazy(FlipX(), rect)
         @test v === view(rect, 1:1:2, 3:-1:1)
         @test v == flipdim(rect,2)
         @test typeof(v) <: SubArray
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(FlipX)) === false
+        @test Augmentor.supports_permute(FlipX) === false
     end
 end
 
@@ -62,24 +70,32 @@ end
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(FlipY(), nothing)
-        @test @inferred(Augmentor.supports_eager(FlipY)) === true
+        @test Augmentor.supports_eager(FlipY) === true
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(FlipY(), img)) == flipdim(rect,1)
             @test typeof(Augmentor.applyeager(FlipY(), img)) <: Array
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(FlipY)) === true
-        @test @inferred(Augmentor.supports_affine(FlipY)) === true
+        @test Augmentor.supports_affine(FlipY) === true
         @test_throws MethodError Augmentor.applyaffine(FlipY(), nothing)
-        @test @inferred(Augmentor.toaffine(FlipY(), rect)) ≈ AffineMap([-1. 0.; 0. 1.], [3.0,0.0])
+        @test @inferred(Augmentor.toaffinemap(FlipY(), rect)) ≈ AffineMap([-1. 0.; 0. 1.], [3.0,0.0])
         wv = @inferred Augmentor.applyaffine(FlipY(), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == flipdim(square,1)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(FlipY) === true
+        @test_throws MethodError Augmentor.applyaffineview(FlipY(), nothing)
+        wv = @inferred Augmentor.applyaffineview(FlipY(), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == flipdim(square,1)
+    end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(FlipY)) === true
+        @test Augmentor.supports_lazy(FlipY) === true
         v = @inferred Augmentor.applylazy(FlipY(), rect)
         @test v === view(rect, 2:-1:1, 1:1:3)
         @test v == flipdim(rect,1)
@@ -90,16 +106,16 @@ end
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(FlipY)) === false
+        @test Augmentor.supports_view(FlipY) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(FlipY)) === true
+        @test Augmentor.supports_stepview(FlipY) === true
         v = @inferred Augmentor.applylazy(FlipY(), rect)
         @test v === view(rect, 2:-1:1, 1:1:3)
         @test v == flipdim(rect,1)
         @test typeof(v) <: SubArray
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(FlipY)) === false
+        @test Augmentor.supports_permute(FlipY) === false
     end
 end

--- a/test/operations/tst_noop.jl
+++ b/test/operations/tst_noop.jl
@@ -7,35 +7,42 @@
 end
 @testset "eager" begin
     @test_throws MethodError Augmentor.applyeager(NoOp(), nothing)
-    @test @inferred(Augmentor.supports_eager(NoOp)) === false
+    @test Augmentor.supports_eager(NoOp) === false
     @test @inferred(Augmentor.applyeager(NoOp(), rect)) === rect
     @test @inferred(Augmentor.applyeager(NoOp(), view(rect,:,:))) == rect
     @test @inferred(Augmentor.applyeager(NoOp(), OffsetArray(rect, (-1,-2)))) === rect
 end
 @testset "affine" begin
-    @test_throws MethodError Augmentor.toaffine(NoOp(), nothing)
-    @test @inferred(Augmentor.isaffine(NoOp)) === true
-    @test @inferred(Augmentor.supports_affine(NoOp)) === true
-    @test @inferred(Augmentor.toaffine(NoOp(), rect)) == AffineMap(@SMatrix([1. 0; 0 1]), @SVector([0., 0.]))
+    @test_throws MethodError Augmentor.toaffinemap(NoOp(), nothing)
+    @test Augmentor.supports_affine(NoOp) === true
+    @test @inferred(Augmentor.toaffinemap(NoOp(), rect)) == AffineMap(@SMatrix([1. 0; 0 1]), @SVector([0., 0.]))
     wv = @inferred Augmentor.applyaffine(NoOp(), rect)
     @test wv == rect
     @test typeof(wv) <: InvWarpedView{eltype(rect),2}
 end
+@testset "affineview" begin
+    @test Augmentor.supports_affineview(NoOp) === true
+    wv = @inferred Augmentor.applyaffineview(NoOp(), rect)
+    @test typeof(wv) <: SubArray{eltype(rect),2}
+    @test typeof(parent(wv)) <: InvWarpedView
+    @test parent(parent(wv)) === rect
+    @test wv == rect
+end
 @testset "lazy" begin
-    @test @inferred(Augmentor.supports_lazy(NoOp)) === true
+    @test Augmentor.supports_lazy(NoOp) === true
     @test @inferred(Augmentor.applylazy(NoOp(), nothing)) === nothing
     @test @inferred(Augmentor.applylazy(NoOp(), rect)) === rect
     wv = Augmentor.prepareaffine(rect)
     @test @inferred(Augmentor.applylazy(NoOp(), wv)) === wv
 end
 @testset "view" begin
-    @test @inferred(Augmentor.supports_view(NoOp)) === true
+    @test Augmentor.supports_view(NoOp) === true
     @test @inferred(Augmentor.applyview(NoOp(), rect)) === view(rect, IdentityRange(1:2), IdentityRange(1:3))
 end
 @testset "stepview" begin
-    @test @inferred(Augmentor.supports_stepview(NoOp)) === true
+    @test Augmentor.supports_stepview(NoOp) === true
     @test @inferred(Augmentor.applystepview(NoOp(), rect)) === view(rect, 1:1:2, 1:1:3)
 end
 @testset "permute" begin
-    @test @inferred(Augmentor.supports_permute(NoOp)) === false
+    @test Augmentor.supports_permute(NoOp) === false
 end

--- a/test/operations/tst_resize.jl
+++ b/test/operations/tst_resize.jl
@@ -28,7 +28,7 @@
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(Resize(10,10), nothing)
-        @test @inferred(Augmentor.supports_eager(Resize)) === true
+        @test Augmentor.supports_eager(Resize) === true
         ref = Gray{N0f8}[0.624 0.686 0.733 0.686 0.612; 0.667 0.055 0.71 0.675 0.596; 0.639 0.043 0.227 0.631 0.604; 0.569 0.031 0.518 0.553 0.529; 0.392 0.145 0.392 0.443 0.369]
         for img in (camera, OffsetArray(camera, -10, 30), view(camera, IdentityRange(1:512), IdentityRange(1:512)))
             @test @inferred(Augmentor.applyeager(Resize(5,5), img)) == ref
@@ -36,46 +36,48 @@
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(Resize)) === false
-        @test @inferred(Augmentor.supports_affine(Resize)) === true
-        @test_throws MethodError Augmentor.applyaffine(Resize(10,10), nothing)
-        @test @inferred(Augmentor.toaffine(Resize(4,9), rect)) ≈ AffineMap([2. 0.; 0. 3], [-0.5,-1.0])
+        @test Augmentor.supports_affine(Resize) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Resize) === true
+        @test_throws MethodError Augmentor.applyaffineview(Resize(10,10), nothing)
+        @test @inferred(Augmentor.toaffinemap(Resize(4,9), rect)) ≈ AffineMap([2. 0.; 0. 3], [-0.5,-1.0])
         for h in (1,2,3,4,5,9), w in (1,2,3,4,5,9)
-            wv = @inferred Augmentor.applyaffine(Resize(h,w), Augmentor.prepareaffine(square))
+            wv = @inferred Augmentor.applyaffineview(Resize(h,w), Augmentor.prepareaffine(square))
             @test eltype(wv) == eltype(square)
             @test typeof(wv) <: SubArray
             @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
             @test typeof(parent(wv)) <: InvWarpedView
             @test parent(parent(wv)).itp.coefs === square
             # round because `imresize` computes as float space,
-            # while applyaffine doesn't
+            # while applyaffineview doesn't
             @test round.(Float64.(wv),1) == round.(Float64.(imresize(square, h, w)),1)
         end
         for h in (1,2,3,4,5,9), w in (1,2,3,4,5,9) # bigger show drift
-            wv = @inferred Augmentor.applyaffine(Resize(h,w), Augmentor.prepareaffine(checkers))
+            wv = @inferred Augmentor.applyaffineview(Resize(h,w), Augmentor.prepareaffine(checkers))
             @test eltype(wv) == eltype(checkers)
             @test typeof(wv) <: SubArray
             @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
             @test typeof(parent(wv)) <: InvWarpedView
             @test parent(parent(wv)).itp.coefs === checkers
             # round because `imresize` computes as float space,
-            # while applyaffine doesn't
+            # while applyaffineview doesn't
             @test wv == imresize(checkers, h, w)
         end
         for h in (3,10,29,30,64), w in (3,10,29,30,64)
-            wv = @inferred Augmentor.applyaffine(Resize(h,w), Augmentor.prepareaffine(camera))
+            wv = @inferred Augmentor.applyaffineview(Resize(h,w), Augmentor.prepareaffine(camera))
             @test eltype(wv) == eltype(camera)
             @test typeof(wv) <: SubArray
             @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
             @test typeof(parent(wv)) <: InvWarpedView
             @test parent(parent(wv)).itp.coefs === camera
             # round because `imresize` computes as float space,
-            # while applyaffine doesn't
+            # while applyaffineview doesn't
             @test wv == imresize(camera, h, w)
         end
     end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(Resize)) === true
+        @test Augmentor.supports_lazy(Resize) === true
         wv = @inferred Augmentor.applylazy(Resize(2,3), square)
         @test eltype(wv) == eltype(square)
         @test typeof(wv) <: SubArray
@@ -86,12 +88,12 @@
         @test wv == imresize(square, 2, 3)
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(Resize)) === false
+        @test Augmentor.supports_view(Resize) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(Resize)) === false
+        @test Augmentor.supports_stepview(Resize) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(Resize)) === false
+        @test Augmentor.supports_permute(Resize) === false
     end
 end

--- a/test/operations/tst_rotation.jl
+++ b/test/operations/tst_rotation.jl
@@ -8,24 +8,32 @@
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(Rotate90(), nothing)
-        @test @inferred(Augmentor.supports_eager(Rotate90)) === true
+        @test Augmentor.supports_eager(Rotate90) === true
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(Rotate90(), img)) == rotl90(rect)
             @test typeof(Augmentor.applyeager(Rotate90(), img)) <: Array
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(Rotate90)) === true
-        @test @inferred(Augmentor.supports_affine(Rotate90)) === true
+        @test Augmentor.supports_affine(Rotate90) === true
         @test_throws MethodError Augmentor.applyaffine(Rotate90(), nothing)
-        @test @inferred(Augmentor.toaffine(Rotate90(), rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
+        @test @inferred(Augmentor.toaffinemap(Rotate90(), rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
         wv = @inferred Augmentor.applyaffine(Rotate90(), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotl90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Rotate90) === true
+        @test_throws MethodError Augmentor.applyaffineview(Rotate90(), nothing)
+        wv = @inferred Augmentor.applyaffineview(Rotate90(), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == rotl90(square)
+    end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(Rotate90)) === true
+        @test Augmentor.supports_lazy(Rotate90) === true
         v = @inferred Augmentor.applylazy(Rotate90(), rect)
         @test v === view(permuteddimsview(rect, (2,1)), 3:-1:1, 1:1:2)
         @test v == rotl90(rect)
@@ -40,13 +48,13 @@
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(Rotate90)) === false
+        @test Augmentor.supports_view(Rotate90) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(Rotate90)) === false
+        @test Augmentor.supports_stepview(Rotate90) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(Rotate90)) === true
+        @test Augmentor.supports_permute(Rotate90) === true
         v = @inferred Augmentor.applypermute(Rotate90(), rect)
         @test v === view(permuteddimsview(rect, (2,1)), 3:-1:1, 1:1:2)
         @test v == rotl90(rect)
@@ -69,24 +77,32 @@ end
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(Rotate180(), nothing)
-        @test @inferred(Augmentor.supports_eager(Rotate180)) === true
+        @test Augmentor.supports_eager(Rotate180) === true
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(Rotate180(), img)) == rot180(rect)
             @test typeof(Augmentor.applyeager(Rotate180(), img)) <: Array
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(Rotate180)) === true
-        @test @inferred(Augmentor.supports_affine(Rotate180)) === true
+        @test Augmentor.supports_affine(Rotate180) === true
         @test_throws MethodError Augmentor.applyaffine(Rotate180(), nothing)
-        @test @inferred(Augmentor.toaffine(Rotate180(), rect)) ≈ AffineMap([-1.0 -1.22465e-16; 1.22465e-16 -1.0], [3.0,4.0])
+        @test @inferred(Augmentor.toaffinemap(Rotate180(), rect)) ≈ AffineMap([-1.0 -1.22465e-16; 1.22465e-16 -1.0], [3.0,4.0])
         wv = @inferred Augmentor.applyaffine(Rotate180(), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv[1:3,1:3] == rot180(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Rotate180) === true
+        @test_throws MethodError Augmentor.applyaffineview(Rotate180(), nothing)
+        wv = @inferred Augmentor.applyaffineview(Rotate180(), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv[1:3,1:3] == rot180(square)
+    end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(Rotate180)) === true
+        @test Augmentor.supports_lazy(Rotate180) === true
         v = @inferred Augmentor.applylazy(Rotate180(), rect)
         @test v === view(rect, 2:-1:1, 3:-1:1)
         @test v == rot180(rect)
@@ -97,10 +113,10 @@ end
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(Rotate180)) === false
+        @test Augmentor.supports_view(Rotate180) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(Rotate180)) === true
+        @test Augmentor.supports_stepview(Rotate180) === true
         v = @inferred Augmentor.applylazy(Rotate180(), rect)
         @test v === view(rect, 2:-1:1, 3:-1:1)
         @test v == rot180(rect)
@@ -112,7 +128,7 @@ end
         @test typeof(v) <: SubArray
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(Rotate180)) === false
+        @test Augmentor.supports_permute(Rotate180) === false
     end
 end
 
@@ -128,24 +144,32 @@ end
     end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(Rotate270(), nothing)
-        @test @inferred(Augmentor.supports_eager(Rotate270)) === true
+        @test Augmentor.supports_eager(Rotate270) === true
         for img in (rect, OffsetArray(rect, -2, -1), view(rect, IdentityRange(1:2), IdentityRange(1:3)))
             @test @inferred(Augmentor.applyeager(Rotate270(), img)) == rotr90(rect)
             @test typeof(Augmentor.applyeager(Rotate270(), img)) <: Array
         end
     end
     @testset "affine" begin
-        @test @inferred(Augmentor.isaffine(Rotate270)) === true
-        @test @inferred(Augmentor.supports_affine(Rotate270)) === true
+        @test Augmentor.supports_affine(Rotate270) === true
         @test_throws MethodError Augmentor.applyaffine(Rotate270(), nothing)
-        @test @inferred(Augmentor.toaffine(Rotate270(), rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
+        @test @inferred(Augmentor.toaffinemap(Rotate270(), rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
         wv = @inferred Augmentor.applyaffine(Rotate270(), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotr90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Rotate270) === true
+        @test_throws MethodError Augmentor.applyaffineview(Rotate270(), nothing)
+        wv = @inferred Augmentor.applyaffineview(Rotate270(), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == rotr90(square)
+    end
     @testset "lazy" begin
-        @test @inferred(Augmentor.supports_lazy(Rotate270)) === true
+        @test Augmentor.supports_lazy(Rotate270) === true
         v = @inferred Augmentor.applylazy(Rotate270(), rect)
         @test v === view(permuteddimsview(rect, (2,1)), 1:1:3, 2:-1:1)
         @test v == rotr90(rect)
@@ -160,13 +184,13 @@ end
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
     end
     @testset "view" begin
-        @test @inferred(Augmentor.supports_view(Rotate270)) === false
+        @test Augmentor.supports_view(Rotate270) === false
     end
     @testset "stepview" begin
-        @test @inferred(Augmentor.supports_stepview(Rotate270)) === false
+        @test Augmentor.supports_stepview(Rotate270) === false
     end
     @testset "permute" begin
-        @test @inferred(Augmentor.supports_permute(Rotate270)) === true
+        @test Augmentor.supports_permute(Rotate270) === true
         v = @inferred Augmentor.applypermute(Rotate270(), rect)
         @test v === view(permuteddimsview(rect, (2,1)), 1:1:3, 2:-1:1)
         @test v == rotr90(rect)
@@ -216,12 +240,11 @@ end
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(Rotate) === true
         @test Augmentor.supports_affine(Rotate) === true
         @test_throws MethodError Augmentor.applyaffine(Rotate(90), nothing)
-        @test @inferred(Augmentor.toaffine(Rotate(45), rect)) ≈ AffineMap([0.70710678118 -0.70710678118; 0.70710678118 0.70710678118], [1.85355339059,-0.47487373415])
-        @test @inferred(Augmentor.toaffine(Rotate(90), rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
-        @test @inferred(Augmentor.toaffine(Rotate(-90), rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
+        @test @inferred(Augmentor.toaffinemap(Rotate(45), rect)) ≈ AffineMap([0.70710678118 -0.70710678118; 0.70710678118 0.70710678118], [1.85355339059,-0.47487373415])
+        @test @inferred(Augmentor.toaffinemap(Rotate(90), rect)) ≈ AffineMap([6.12323e-17 -1.0; 1.0 6.12323e-17], [3.5,0.5])
+        @test @inferred(Augmentor.toaffinemap(Rotate(-90), rect)) ≈ AffineMap([6.12323e-17 1.0; -1.0 6.12323e-17], [-0.5,3.5])
         wv = @inferred Augmentor.applyaffine(Rotate(90), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test wv == rotl90(square)
@@ -230,6 +253,20 @@ end
         @test parent(wv).itp.coefs === square
         @test wv == rotr90(square)
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Rotate) === true
+        @test_throws MethodError Augmentor.applyaffineview(Rotate(90), nothing)
+        wv = @inferred Augmentor.applyaffineview(Rotate(90), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == rotl90(square)
+        wv = @inferred Augmentor.applyaffineview(Rotate(-90), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test wv == rotr90(square)
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(Rotate(90)) === true

--- a/test/operations/tst_scale.jl
+++ b/test/operations/tst_scale.jl
@@ -64,15 +64,23 @@
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(Scale) === true
         @test Augmentor.supports_affine(Scale) === true
         @test_throws MethodError Augmentor.applyaffine(Scale(90), nothing)
-        @test @inferred(Augmentor.toaffine(Scale(2,3), rect)) ≈ AffineMap([2. 0.; 0. 3.], [-1.5,-4.0])
-        @test @inferred(Augmentor.toaffine(Scale([0.9,0.9],[0.8,0.8]), rect)) ≈ AffineMap([.9 0.; 0. .8], [0.15,0.4])
+        @test @inferred(Augmentor.toaffinemap(Scale(2,3), rect)) ≈ AffineMap([2. 0.; 0. 3.], [-1.5,-4.0])
+        @test @inferred(Augmentor.toaffinemap(Scale([0.9,0.9],[0.8,0.8]), rect)) ≈ AffineMap([.9 0.; 0. .8], [0.15,0.4])
         wv = @inferred Augmentor.applyaffine(Scale(2,3), Augmentor.prepareaffine(square))
         # TODO: better tests
         @test parent(wv).itp.coefs === square
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Scale) === true
+        @test_throws MethodError Augmentor.applyaffineview(Scale(90), nothing)
+        wv = @inferred Augmentor.applyaffineview(Scale(2,3), Augmentor.prepareaffine(square))
+        # TODO: better tests
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(Scale) === true

--- a/test/operations/tst_shear.jl
+++ b/test/operations/tst_shear.jl
@@ -43,11 +43,10 @@
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(ShearX) === true
         @test Augmentor.supports_affine(ShearX) === true
         @test_throws MethodError Augmentor.applyaffine(ShearX(45), nothing)
-        @test @inferred(Augmentor.toaffine(ShearX(45), rect)) ≈ AffineMap([1. 0.; -1. 1.], [0.,1.5])
-        @test @inferred(Augmentor.toaffine(ShearX(-45), rect)) ≈ AffineMap([1. 0.; 1. 1.], [0.,-1.5])
+        @test @inferred(Augmentor.toaffinemap(ShearX(45), rect)) ≈ AffineMap([1. 0.; -1. 1.], [0.,1.5])
+        @test @inferred(Augmentor.toaffinemap(ShearX(-45), rect)) ≈ AffineMap([1. 0.; 1. 1.], [0.,-1.5])
         wv = @inferred Augmentor.applyaffine(ShearX(45), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test indices(wv) == (1:3,0:4)
@@ -56,6 +55,20 @@
         @test parent(wv).itp.coefs === square
         @test wv2[1:3,1:3] == square
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(ShearX) === true
+        @test_throws MethodError Augmentor.applyaffineview(ShearX(45), nothing)
+        wv = @inferred Augmentor.applyaffineview(ShearX(45), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test indices(wv) == (1:3,0:4)
+        wv2 = @inferred Augmentor.applyaffineview(ShearX(-45), wv)
+        @test wv2[1:3,1:3] == square
+        @test typeof(wv2) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv2)) <: InvWarpedView
+        @test parent(parent(wv2)).itp.coefs === square
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(ShearX(45)) === true
@@ -126,11 +139,10 @@ end
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(ShearY) === true
         @test Augmentor.supports_affine(ShearY) === true
         @test_throws MethodError Augmentor.applyaffine(ShearY(45), nothing)
-        @test @inferred(Augmentor.toaffine(ShearY(45), rect)) ≈ AffineMap([1. -1.; 0. 1.], [2.,0.])
-        @test @inferred(Augmentor.toaffine(ShearY(-45), rect)) ≈ AffineMap([1. 1.; 0. 1.], [-2.,0.])
+        @test @inferred(Augmentor.toaffinemap(ShearY(45), rect)) ≈ AffineMap([1. -1.; 0. 1.], [2.,0.])
+        @test @inferred(Augmentor.toaffinemap(ShearY(-45), rect)) ≈ AffineMap([1. 1.; 0. 1.], [-2.,0.])
         wv = @inferred Augmentor.applyaffine(ShearY(45), Augmentor.prepareaffine(square))
         @test parent(wv).itp.coefs === square
         @test indices(wv) == (0:4,1:3)
@@ -139,6 +151,20 @@ end
         @test parent(wv).itp.coefs === square
         @test wv2[1:3,1:3] == square
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(ShearY) === true
+        @test_throws MethodError Augmentor.applyaffineview(ShearY(45), nothing)
+        wv = @inferred Augmentor.applyaffineview(ShearY(45), Augmentor.prepareaffine(square))
+        @test typeof(wv) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv)) <: InvWarpedView
+        @test parent(parent(wv)).itp.coefs === square
+        @test indices(wv) == (0:4,1:3)
+        wv2 = @inferred Augmentor.applyaffineview(ShearY(-45), wv)
+        @test typeof(wv2) <: SubArray{eltype(square),2}
+        @test typeof(parent(wv2)) <: InvWarpedView
+        @test parent(parent(wv2)).itp.coefs === square
+        @test wv2[1:3,1:3] == square
     end
     @testset "lazy" begin
         @test Augmentor.supports_lazy(ShearY(45)) === true

--- a/test/operations/tst_zoom.jl
+++ b/test/operations/tst_zoom.jl
@@ -65,12 +65,14 @@
         end
     end
     @testset "affine" begin
-        @test Augmentor.isaffine(Zoom) === false
-        @test Augmentor.supports_affine(Zoom) === true
-        @test_throws MethodError Augmentor.applyaffine(Zoom(90), nothing)
-        @test @inferred(Augmentor.toaffine(Zoom(2,3), rect)) ≈ AffineMap([2. 0.; 0. 3.], [-1.5,-4.0])
-        @test @inferred(Augmentor.toaffine(Zoom([0.9,0.9],[0.8,0.8]), rect)) ≈ AffineMap([.9 0.; 0. .8], [0.15,0.4])
-        wv = @inferred Augmentor.applyaffine(Zoom(2,3), Augmentor.prepareaffine(square))
+        @test Augmentor.supports_affine(Zoom) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(Zoom) === true
+        @test_throws MethodError Augmentor.applyaffineview(Zoom(90), nothing)
+        @test @inferred(Augmentor.toaffinemap(Zoom(2,3), rect)) ≈ AffineMap([2. 0.; 0. 3.], [-1.5,-4.0])
+        @test @inferred(Augmentor.toaffinemap(Zoom([0.9,0.9],[0.8,0.8]), rect)) ≈ AffineMap([.9 0.; 0. .8], [0.15,0.4])
+        wv = @inferred Augmentor.applyaffineview(Zoom(2,3), Augmentor.prepareaffine(square))
         # TODO: better tests
         @test eltype(wv) == eltype(square)
         @test typeof(wv) <: SubArray

--- a/test/tst_augment.jl
+++ b/test/tst_augment.jl
@@ -84,7 +84,7 @@ end
 ops = Augmentor.ImmutablePipeline(Rotate(90),Rotate(-90)) # forces affine
 @testset "$(str_showcompact(ops))" begin
     wv = @inferred Augmentor._augment(camera, ops)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == camera
 end
 
@@ -104,15 +104,22 @@ end
 ops = (ShearX(45),ShearX(-45)) # forces affine
 @testset "$(str_showcompact(ops))" begin
     wv = @inferred Augmentor._augment(camera, ops)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test view(wv,1:512,1:512) == camera
 end
 
 ops = (ShearY(45),ShearY(-45)) # forces affine
 @testset "$(str_showcompact(ops))" begin
     wv = @inferred Augmentor._augment(camera, ops)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test view(wv,1:512,1:512) == camera
+end
+
+ops = (ShearY(45),ShearX(-2),CacheImage()) # forces affine then eager
+@testset "$(str_showcompact(ops))" begin
+    img = @inferred Augmentor._augment(camera, ops)
+    @test typeof(img) <: OffsetArray
+    @test indices(img) == (-255:768, 0:512)
 end
 
 ops = (Resize(2,2),Rotate90()) # forces affine
@@ -335,4 +342,4 @@ ops = (Rotate(45),Zoom(2))
 end
 
 # just for code coverage
-@test typeof(@inferred(Augmentor.build_pipeline(Rotate90()))) <: Expr
+@test typeof(@inferred(Augmentor.augment_impl(Rotate90()))) <: Expr

--- a/test/tst_operations.jl
+++ b/test/tst_operations.jl
@@ -7,9 +7,6 @@
 @test Augmentor.AffineOperation <: Augmentor.ImageOperation
 
 @testset "prepare" begin
-    @test @inferred(Augmentor.prepareview(rect)) === rect
-    @test @inferred(Augmentor.preparestepview(rect)) === rect
-    @test @inferred(Augmentor.preparepermute(rect)) === rect
     @test @inferred(Augmentor.preparelazy(rect)) === rect
     wv = @inferred Augmentor.prepareaffine(rect)
     @test typeof(wv) <: InvWarpedView
@@ -23,35 +20,35 @@ end
 
 ops = (Zoom(2.), NoOp()) # make sure Zoom sticks
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
     @test typeof(wv) <: SubArray
     @test indices(wv) == (1:2,1:3)
 end
 
 ops = (FlipX(), FlipY())
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == rot180(rect)
-    wv = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(rect))
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(rect))
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == rot180(rect)
-    v = @inferred Augmentor.applylazy(ops, rect)
+    v = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test v === view(rect, 2:-1:1, 3:-1:1)
     @test v == rot180(rect)
 end
 
 ops = (Rotate90(), Rotate270())
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == rect
-    wv = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(rect))
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(rect))
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == rect
     img = @inferred Augmentor.applyeager(Resize(4,4), wv)
     @test img == imresize(rect, (4,4))
-    v = @inferred Augmentor.applylazy(ops, rect)
+    v = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test v === view(rect, 1:1:2, 1:1:3)
     @test v == rect
     img = @inferred Augmentor.applyeager(Resize(4,4), v)
@@ -60,135 +57,135 @@ end
 
 ops = (Rotate90(), Resize(3,3))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == rotl90(square)
-    wv = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == rotl90(square)
 end
 
 ops = (Rotate90(), Resize(2,2))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == imresize(rotl90(square), 2, 2)
-    wv = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == imresize(rotl90(square), 2, 2)
 end
 
 ops = (Rotate90(), Resize(5,9))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == imresize(rotl90(square), 5, 9)
-    wv = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
-    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffine(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
+    @test typeof(wv) === typeof(view(invwarpedview(square, Augmentor.toaffinemap(NoOp(),square), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
     @test wv == imresize(rotl90(square), 5, 9)
 end
 
 ops = (Rotate(-90), Rotate90())
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv == rect
-    wv2 = @inferred Augmentor.applylazy(ops, rect)
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test typeof(wv2) == typeof(wv)
     @test wv2 == rect
 end
 
 ops = (Rotate(-90), Crop(1:2,1:3), Rotate90()) # affine forces affine
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
-    @test typeof(wv) === typeof(view(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
-    wv2 = @inferred Augmentor.applylazy(ops, rect)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
+    @test typeof(wv) === typeof(view(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()),IdentityRange(1:2),IdentityRange(1:2)))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test typeof(wv2) == typeof(wv)
 end
 
 ops = (Rotate90(), Rotate270(), Rotate180())
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, rect)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, rect)
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv[1:2,1:3] == rot180(rect)
-    wv2 = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(rect))
-    @test typeof(wv2) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),rect), Flat()))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(rect))
+    @test typeof(wv2) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),rect), Flat()))
     @test wv2 == wv
-    v = @inferred Augmentor.applylazy(ops, rect)
+    v = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test v === view(rect, 2:-1:1, 3:-1:1)
     @test v == rot180(rect)
 end
 
 ops = (Rotate180(), Either((Rotate90(), Rotate270()), (1,0)))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
-    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffine(NoOp(),square), Flat()))
-    r1 = invwarpedview(square, Augmentor.toaffine(Rotate180(),square), Flat())
-    @test wv == invwarpedview(r1, Augmentor.toaffine(Rotate90(), r1))
-    wv2 = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
+    @test typeof(wv) === typeof(invwarpedview(rect, Augmentor.toaffinemap(NoOp(),square), Flat()))
+    r1 = invwarpedview(square, Augmentor.toaffinemap(Rotate180(),square), Flat())
+    @test wv == invwarpedview(r1, Augmentor.toaffinemap(Rotate90(), r1))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
     @test wv2 == wv
-    v = @inferred Augmentor.applylazy(ops, rect)
+    v = @inferred Augmentor.unroll_applylazy(ops, rect)
     @test v === view(permuteddimsview(rect, (2,1)), 1:1:3, 2:-1:1)
     @test v == rotl90(rot180(rect))
 end
 
 ops = (Crop(1:2,2:3), Either((Rotate90(), Rotate270()), (1,0)))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
     @test typeof(wv) <: SubArray
     @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
     @test typeof(parent(wv)) <: InvWarpedView
     @test parent(parent(wv)).itp.coefs === square
     @test parent(copy(wv)) == rotl90(view(square, 1:2, 2:3))
-    wv2 = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
     @test wv2 == wv
     @test typeof(wv2) == typeof(wv)
-    v = @inferred Augmentor.applylazy(ops, square)
+    v = @inferred Augmentor.unroll_applylazy(ops, square)
     @test v === view(permuteddimsview(square,(2,1)), 3:-1:2, 1:1:2)
     @test v == rotl90(view(square, 1:2, 2:3))
 end
 
 ops = (Rotate180(), CropNative(1:2,2:3))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
     @test typeof(wv) <: SubArray
     @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
     @test typeof(parent(wv)) <: InvWarpedView
     @test parent(parent(wv)).itp.coefs === square
     @test wv == view(rot180(square), IdentityRange(1:2), IdentityRange(2:3))
-    wv2 = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
     @test wv2 == wv
     @test typeof(wv2) == typeof(wv)
-    v = @inferred Augmentor.applylazy(ops, square)
+    v = @inferred Augmentor.unroll_applylazy(ops, square)
     @test v === view(square, 3:-1:2, 2:-1:1)
     @test v == view(rot180(square), 1:2, 2:3)
 end
 
 ops = (Rotate180(), CropSize(2,2))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, square)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, square)
     @test typeof(wv) <: SubArray
     @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
     @test typeof(parent(wv)) <: InvWarpedView
     @test parent(parent(wv)).itp.coefs === square
     @test wv == view(rot180(square), IdentityRange(1:2), IdentityRange(2:3))
-    wv2 = @inferred Augmentor.applylazy(ops, Augmentor.prepareaffine(square))
+    wv2 = @inferred Augmentor.unroll_applylazy(ops, Augmentor.prepareaffine(square))
     @test wv2 == wv
     @test typeof(wv2) == typeof(wv)
-    v = @inferred Augmentor.applylazy(ops, square)
+    v = @inferred Augmentor.unroll_applylazy(ops, square)
     @test v === view(square, 3:-1:2, 3:-1:2)
     @test v == view(rot180(square), 1:2, 1:2)
 end
 
 ops = (Either((Rotate90(),Rotate270()),(1,0)), Crop(20:30,100:150), Either((Rotate90(),Rotate270()),(0,1)))
 @testset "$(str_showcompact(ops))" begin
-    wv = @inferred Augmentor.applyaffine(ops, camera)
+    wv = @inferred Augmentor.unroll_applyaffine(ops, camera)
     @test typeof(wv) <: SubArray
     @test typeof(wv.indexes) <: Tuple{Vararg{IdentityRange}}
     @test typeof(parent(wv)) <: InvWarpedView
     @test parent(parent(wv)).itp.coefs === camera
     @test parent(copy(wv)) == rotr90(view(rotl90(camera), 20:30, 100:150))
-    v = @inferred Augmentor.applylazy(ops, camera)
+    v = @inferred Augmentor.unroll_applylazy(ops, camera)
     @test v === view(camera, 100:1:150, 483:1:493)
     @test v == parent(copy(wv))
     @test v == rotr90(view(rotl90(camera), 20:30, 100:150))


### PR DESCRIPTION
Before this PR the predicate `supports_affine` didn't really have the same kind of semantics as the other predicates such as `supports_view` etc. This was an artefact of early glue code, where I wanted to be able to chain affine operations, such as `Rotate` with non-affine operations such as `Crop`.

With this PR I split up `supports_affine` into a true `supports_affine` (`Rotate` etc) and `supports_affineview` (`Rotate` `Crop` `Resize`). This will greatly improve the flexibility of `Either` as it can now lazily combine things like `Rotate` and `Crop`.

Aside from this major change I renamed some non-exported functions to improve clarity 