### PR TITLE
add ConvertEltype operation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # v0.2.0
 
+New operations:
+
+- `ConvertEltype`: Convert the array elements to the given type
+
+Other changes:
+
 - `Either` can now lazily combine affine operations with operations
   such as `Crop`, `Zoom`, and `Resize`. This is because a new kind
   of support was introduced called `Augmentor.supports_affineview`,

--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ look at the corresponding section of the
 |               | `CropSize`          | Crop area around the center with specified size.
 |               | `CropRatio`         | Crop to specified aspect ratio.
 |               | `RCropRatio`        | Crop random window of specified aspect ratio.
+| *Conversion:* | `ConvertEltype`     | Convert the array elements to the given type.
 | *Layout:*     | `SplitChannels`     | Separate the color channels into a dedicated array dimension.
 |               | `CombineChannels`   | Collapse the first dimension into a specific colorant.
 |               | `PermuteDims`       | Reorganize the array dimensions into a specific order.

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.6
+MappedArrays 0.0.3
 ImageCore 0.1.2
 ImageTransformations 0.3.0
 ImageFiltering 0.1.4

--- a/docs/usersguide/operations.rst
+++ b/docs/usersguide/operations.rst
@@ -21,6 +21,8 @@ functionality.
 | Cropping              | :class:`Crop` :class:`CropNative` :class:`CropSize` :class:`CropRatio`     |
 |                       | :class:`RCropRatio`                                                        |
 +-----------------------+----------------------------------------------------------------------------+
+| Conversion            | :class:`ConvertEltype`                                                     |
++-----------------------+----------------------------------------------------------------------------+
 | Information Layout    | :class:`SplitChannels` :class:`CombineChannels` :class:`PermuteDims`       |
 |                       | :class:`Reshape`                                                           |
 +-----------------------+----------------------------------------------------------------------------+
@@ -553,6 +555,42 @@ Resizing
 +=========================================================================================================+=========================================================================================================+
 | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/testpattern_small.png | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/Resize.png |
 +---------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------------------+
+
+Conversion
+--------------------
+
+.. class:: ConvertEltype
+
+   Convert the element type of the given array/image into the
+   given ``eltype``. This operation is especially useful for
+   converting color images to grayscale (or the other way
+   around). That said the operation is not specific to color
+   types and can also be used for numeric arrays (e.g. with
+   separated channels).
+
+   Note that this is an element-wise convert function. Thus it
+   can not be used to combine or separate color channels. Use
+   :class:`SplitChannels` or :class:`CombineChannels` for those
+   purposes.
+
+.. code-block:: jlcon
+
+   julia> op = ConvertEltype(Gray)
+   Convert eltype to Gray
+
+   julia> img = testpattern()
+   300×400 Array{RGBA{N0f8},2}:
+   [...]
+
+   julia> augment(img, op)
+   300×400 Array{Gray{N0f8},2}:
+   [...]
+
++----------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| Input                                                                                                          | Output for ``ConvertEltype(GrayA)``                                                                            |
++================================================================================================================+================================================================================================================+
+| .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/testpattern_small.png        | .. image:: https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/ConvertEltype.png |
++----------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------+
 
 Information Layout
 --------------------

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -3,6 +3,7 @@ module Augmentor
 
 using ColorTypes
 using ColorTypes: AbstractGray
+using MappedArrays
 using ImageCore
 using ImageTransformations
 using ImageFiltering
@@ -19,10 +20,15 @@ using Base.PermutedDimsArrays: PermutedDimsArray
 
 export
 
+    Gray,
+    RGB,
+
     SplitChannels,
     CombineChannels,
     PermuteDims,
     Reshape,
+
+    ConvertEltype,
 
     Rotate90,
     Rotate180,
@@ -61,6 +67,7 @@ include("types.jl")
 include("operation.jl")
 
 include("operations/channels.jl")
+include("operations/convert.jl")
 
 include("operations/noop.jl")
 include("operations/cache.jl")

--- a/src/distortedview.jl
+++ b/src/distortedview.jl
@@ -1,4 +1,4 @@
-immutable DistortedView{T,P<:AbstractMatrix,E<:AbstractExtrapolation,G,D} <: AbstractArray{T,2}
+struct DistortedView{T,P<:AbstractMatrix,E<:AbstractExtrapolation,G,D} <: AbstractArray{T,2}
     parent::P
     etp::E
     grid::G

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -51,7 +51,7 @@ see also
 
 [`augment`](@ref)
 """
-immutable CacheImage <: ImageOperation end
+struct CacheImage <: ImageOperation end
 
 applyeager(op::CacheImage, img::Array) = img
 applyeager(op::CacheImage, img::OffsetArray) = img
@@ -79,7 +79,7 @@ end
 
 see [`CacheImage`](@ref)
 """
-immutable CacheImageInto{T<:AbstractArray} <: ImageOperation
+struct CacheImageInto{T<:AbstractArray} <: ImageOperation
     buffer::T
 end
 CacheImage(buffer::AbstractArray) = CacheImageInto(buffer)

--- a/src/operations/channels.jl
+++ b/src/operations/channels.jl
@@ -44,7 +44,7 @@ see also
 
 [`PermuteDims`](@ref), [`CombineChannels`](@ref), [`augment`](@ref)
 """
-immutable SplitChannels <: Operation end
+struct SplitChannels <: Operation end
 
 @inline supports_eager(::Type{SplitChannels}) = false
 @inline supports_lazy(::Type{SplitChannels}) = true
@@ -126,7 +126,7 @@ see also
 
 [`SplitChannels`](@ref), [`PermuteDims`](@ref), [`augment`](@ref)
 """
-immutable CombineChannels{T<:Colorant} <: Operation
+struct CombineChannels{T<:Colorant} <: Operation
     colortype::Type{T}
 end
 
@@ -221,7 +221,7 @@ see also
 
 [`SplitChannels`](@ref), [`CombineChannels`](@ref), [`augment`](@ref)
 """
-immutable PermuteDims{N,perm,iperm} <: Operation end
+struct PermuteDims{N,perm,iperm} <: Operation end
 PermuteDims() = throw(MethodError(PermuteDims, ()))
 PermuteDims(perm::Tuple{}) = throw(MethodError(PermuteDims, (perm,)))
 PermuteDims(perm::NTuple{N,Int}) where {N} = PermuteDims{N,perm,invperm(perm)}()
@@ -297,7 +297,7 @@ see also
 
 [`CombineChannels`](@ref), [`augment`](@ref)
 """
-immutable Reshape{N} <: Operation
+struct Reshape{N} <: Operation
     dims::NTuple{N,Int}
 end
 Reshape() = throw(MethodError(Reshape, ()))

--- a/src/operations/convert.jl
+++ b/src/operations/convert.jl
@@ -1,0 +1,80 @@
+"""
+    ConvertEltype <: Augmentor.Operation
+
+Description
+--------------
+
+Convert the element type of the given array/image into the given
+`eltype`. This operation is especially useful for converting
+color images to grayscale (or the other way around). That said
+the operation is not specific to color types and can also be used
+for numeric arrays (e.g. with separated channels).
+
+Note that this is an element-wise convert function. Thus it can
+not be used to combine or separate color channels. Use
+[`SplitChannels`](@ref) or [`CombineChannels`](@ref) for those
+purposes.
+
+Usage
+--------------
+
+    ConvertEltype(eltype)
+
+Arguments
+--------------
+
+- **`eltype`** : The eltype of the resulting array/image.
+
+Examples
+--------------
+
+```julia
+julia> using Augmentor, Colors
+
+julia> A = rand(RGB, 10, 10) # three color channels
+10×10 Array{RGB{Float64},2}:
+[...]
+
+julia> augment(A, ConvertEltype(Gray)) # convert to grayscale
+10×10 Array{Gray{Float64},2}:
+[...]
+
+julia> augment(A, ConvertEltype(Gray{Float32})) # more specific
+10×10 Array{Gray{Float32},2}:
+[...]
+```
+
+see also
+--------------
+
+[`CombineChannels`](@ref), [`SplitChannels`](@ref), [`augment`](@ref)
+"""
+struct ConvertEltype{T} <: Operation
+    eltype::Type{T}
+end
+
+@inline supports_lazy(::Type{<:ConvertEltype}) = true
+
+function applyeager(op::ConvertEltype{T}, img::AbstractArray) where T
+    convert(Array{T}, img)
+end
+
+function applylazy(op::ConvertEltype{T}, img::AbstractArray) where T
+    mappedarray(c->convert(T,c), img)
+end
+
+function showconstruction(io::IO, op::ConvertEltype)
+    print(io, typeof(op).name.name, '(')
+    ImageCore.showcoloranttype(io, op.eltype)
+    print(io, ')')
+end
+
+function Base.show(io::IO, op::ConvertEltype)
+    if get(io, :compact, false)
+        print(io, "Convert eltype to ")
+        ImageCore.showcoloranttype(io, op.eltype)
+    else
+        print(io, "Augmentor.")
+        showconstruction(io, op)
+    end
+end

--- a/src/operations/crop.jl
+++ b/src/operations/crop.jl
@@ -48,7 +48,7 @@ see also
 
 [`CropNative`](@ref), [`CropSize`](@ref), [`CropRatio`](@ref), [`augment`](@ref)
 """
-immutable Crop{N,I<:Tuple} <: ImageOperation
+struct Crop{N,I<:Tuple} <: ImageOperation
     indexes::I
 
     function Crop{N}(indexes::NTuple{N,UnitRange}) where N
@@ -143,7 +143,7 @@ see also
 
 [`Crop`](@ref), [`CropSize`](@ref), [`CropRatio`](@ref), [`augment`](@ref)
 """
-immutable CropNative{N,I<:Tuple} <: ImageOperation
+struct CropNative{N,I<:Tuple} <: ImageOperation
     indexes::I
 
     function CropNative{N}(indexes::NTuple{N,UnitRange}) where N
@@ -229,7 +229,7 @@ see also
 
 [`CropRatio`](@ref), [`Crop`](@ref), [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable CropSize{N} <: ImageOperation
+struct CropSize{N} <: ImageOperation
     size::NTuple{N,Int}
 
     function CropSize{N}(size::NTuple{N,Int}) where N
@@ -329,7 +329,7 @@ see also
 
 [`RCropRatio`](@ref), [`CropSize`](@ref), [`Crop`](@ref), [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable CropRatio <: ImageOperation
+struct CropRatio <: ImageOperation
     ratio::Float64
 
     function CropRatio(ratio::Real)
@@ -451,7 +451,7 @@ see also
 
 [`CropRatio`](@ref), [`CropSize`](@ref), [`Crop`](@ref), [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable RCropRatio <: ImageOperation
+struct RCropRatio <: ImageOperation
     ratio::Float64
 
     function RCropRatio(ratio::Real)

--- a/src/operations/distortion.jl
+++ b/src/operations/distortion.jl
@@ -94,7 +94,7 @@ see also
 
 [`RandomDistortion`](@ref), [`augment`](@ref)
 """ ->
-immutable ElasticDistortion <: ImageOperation
+struct ElasticDistortion <: ImageOperation
     gridheight::Int
     gridwidth::Int
     scale::Float64

--- a/src/operations/either.jl
+++ b/src/operations/either.jl
@@ -75,7 +75,7 @@ see also
 
 [`augment`](@ref)
 """
-immutable Either{N,T<:Tuple} <: ImageOperation
+struct Either{N,T<:Tuple} <: ImageOperation
     operations::T
     chances::SVector{N,Float64}
     cum_chances::SVector{N,Float64}

--- a/src/operations/flip.jl
+++ b/src/operations/flip.jl
@@ -51,7 +51,7 @@ see also
 
 [`FlipY`](@ref), [`Either`](@ref), [`augment`](@ref)
 """
-immutable FlipX <: AffineOperation end
+struct FlipX <: AffineOperation end
 FlipX(p::Number) = Either(FlipX(), p)
 
 @inline supports_stepview(::Type{FlipX}) = true
@@ -133,7 +133,7 @@ see also
 
 [`FlipX`](@ref), [`Either`](@ref), [`augment`](@ref)
 """
-immutable FlipY <: AffineOperation end
+struct FlipY <: AffineOperation end
 FlipY(p::Number) = Either(FlipY(), p)
 
 @inline supports_stepview(::Type{FlipY}) = true

--- a/src/operations/noop.jl
+++ b/src/operations/noop.jl
@@ -7,7 +7,7 @@ image but instead passes it along unchanged (without copying).
 Usually used in combination with [`Either`](@ref) to denote a
 "branch" that does not perform any computation.
 """
-immutable NoOp <: AffineOperation end
+struct NoOp <: AffineOperation end
 
 @inline supports_eager(::Type{NoOp}) = false
 @inline supports_stepview(::Type{NoOp}) = true

--- a/src/operations/resize.jl
+++ b/src/operations/resize.jl
@@ -41,7 +41,7 @@ see also
 
 [`CropSize`](@ref), [`augment`](@ref)
 """
-immutable Resize{N} <: ImageOperation
+struct Resize{N} <: ImageOperation
     size::NTuple{N,Int}
 
     function Resize{N}(size::NTuple{N,Int}) where N

--- a/src/operations/rotation.jl
+++ b/src/operations/rotation.jl
@@ -54,7 +54,7 @@ see also
 [`Rotate180`](@ref), [`Rotate270`](@ref), [`Rotate`](@ref),
 [`Either`](@ref), [`augment`](@ref)
 """
-immutable Rotate90 <: AffineOperation end
+struct Rotate90 <: AffineOperation end
 Rotate90(p::Number) = Either(Rotate90(), p)
 
 @inline supports_permute(::Type{Rotate90}) = true
@@ -137,7 +137,7 @@ see also
 [`Rotate90`](@ref), [`Rotate270`](@ref), [`Rotate`](@ref),
 [`Either`](@ref), [`augment`](@ref)
 """
-immutable Rotate180 <: AffineOperation end
+struct Rotate180 <: AffineOperation end
 Rotate180(p::Number) = Either(Rotate180(), p)
 
 @inline supports_stepview(::Type{Rotate180}) = true
@@ -208,7 +208,7 @@ see also
 [`Rotate90`](@ref), [`Rotate180`](@ref), [`Rotate`](@ref),
 [`Either`](@ref), [`augment`](@ref)
 """
-immutable Rotate270 <: AffineOperation end
+struct Rotate270 <: AffineOperation end
 Rotate270(p::Number) = Either(Rotate270(), p)
 
 @inline supports_permute(::Type{Rotate270}) = true
@@ -307,7 +307,7 @@ see also
 [`Rotate90`](@ref), [`Rotate180`](@ref), [`Rotate270`](@ref),
 [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable Rotate{T<:AbstractVector} <: AffineOperation
+struct Rotate{T<:AbstractVector} <: AffineOperation
     degree::T
 
     function Rotate{T}(degree::T) where {T<:AbstractVector{S} where S<:Real}

--- a/src/operations/scale.jl
+++ b/src/operations/scale.jl
@@ -59,7 +59,7 @@ see also
 
 [`Zoom`](@ref), [`Resize`](@ref), [`augment`](@ref)
 """
-immutable Scale{N,T<:AbstractVector} <: AffineOperation
+struct Scale{N,T<:AbstractVector} <: AffineOperation
     factors::NTuple{N,T}
 
     function Scale{N}(factors::NTuple{N,T}) where {N,T<:AbstractVector}

--- a/src/operations/shear.jl
+++ b/src/operations/shear.jl
@@ -48,7 +48,7 @@ see also
 
 [`ShearY`](@ref), [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable ShearX{T<:AbstractVector} <: AffineOperation
+struct ShearX{T<:AbstractVector} <: AffineOperation
     degree::T
 
     function ShearX{T}(degree::T) where {T<:AbstractVector{S} where S<:Real}
@@ -132,7 +132,7 @@ see also
 
 [`ShearX`](@ref), [`CropNative`](@ref), [`augment`](@ref)
 """
-immutable ShearY{T<:AbstractVector} <: AffineOperation
+struct ShearY{T<:AbstractVector} <: AffineOperation
     degree::T
 
     function ShearY{T}(degree::T) where {T<:AbstractVector{S} where S<:Real}

--- a/src/operations/zoom.jl
+++ b/src/operations/zoom.jl
@@ -63,7 +63,7 @@ see also
 
 [`Scale`](@ref), [`Resize`](@ref), [`augment`](@ref)
 """
-immutable Zoom{N,T<:AbstractVector} <: ImageOperation
+struct Zoom{N,T<:AbstractVector} <: ImageOperation
     factors::NTuple{N,T}
 
     function Zoom{N}(factors::NTuple{N,T}) where {N,T<:AbstractVector}

--- a/src/pipeline.jl
+++ b/src/pipeline.jl
@@ -1,4 +1,4 @@
-immutable ImmutablePipeline{N,T<:Tuple} <: Pipeline
+struct ImmutablePipeline{N,T<:Tuple} <: Pipeline
     operations::T
 
     function ImmutablePipeline{N}(ops::NTuple{N,Operation}) where N

--- a/test/operations/tst_convert.jl
+++ b/test/operations/tst_convert.jl
@@ -1,0 +1,75 @@
+@testset "ConvertEltype" begin
+    @test (ConvertEltype <: Augmentor.AffineOperation) == false
+    @test (ConvertEltype <: Augmentor.ImageOperation) == false
+    @test (ConvertEltype <: Augmentor.Operation) == true
+
+    @testset "constructor" begin
+        @test_throws MethodError ConvertEltype()
+        @test typeof(@inferred(ConvertEltype(Float64))) <: ConvertEltype <: Augmentor.Operation
+        @test typeof(@inferred(ConvertEltype(RGB))) <: ConvertEltype <: Augmentor.Operation
+        @test typeof(@inferred(ConvertEltype(RGB{N0f8}))) <: ConvertEltype <: Augmentor.Operation
+        @test str_show(ConvertEltype(Float64)) == "Augmentor.ConvertEltype(Float64)"
+        @test str_show(ConvertEltype(RGB)) == "Augmentor.ConvertEltype(RGB{Any})"
+        @test str_show(ConvertEltype(Gray{N0f8})) == "Augmentor.ConvertEltype(Gray{N0f8})"
+        @test str_showconst(ConvertEltype(Float64)) == "ConvertEltype(Float64)"
+        @test str_showconst(ConvertEltype(RGB{N0f8})) == "ConvertEltype(RGB{N0f8})"
+        @test str_showcompact(ConvertEltype(Float64)) == "Convert eltype to Float64"
+        @test str_showcompact(ConvertEltype(Gray)) == "Convert eltype to Gray{Any}"
+    end
+    @testset "eager" begin
+        @test Augmentor.supports_eager(ConvertEltype) === true
+        @test Augmentor.supports_eager(ConvertEltype{Float64}) === true
+        let img = @inferred(Augmentor.applyeager(ConvertEltype(Gray), rgb_rect))
+            @test typeof(img) == Array{Gray{N0f8},2}
+            @test img == convert.(Gray, rgb_rect)
+        end
+        let img = @inferred(Augmentor.applyeager(ConvertEltype(Gray{Float32}), rgb_rect))
+            @test typeof(img) == Array{Gray{Float32},2}
+            @test img == convert.(Gray{Float32}, rgb_rect)
+        end
+        let img = @inferred(Augmentor.applyeager(ConvertEltype(Float32), checkers))
+            @test typeof(img) == Array{Float32,2}
+            @test img == convert(Array{Float32}, checkers)
+        end
+        let img = @inferred(Augmentor.applyeager(ConvertEltype(RGB), checkers))
+            @test typeof(img) == Array{RGB{N0f8},2}
+            @test img == convert.(RGB, checkers)
+        end
+    end
+    @testset "affine" begin
+        @test Augmentor.supports_affine(ConvertEltype) === false
+    end
+    @testset "affineview" begin
+        @test Augmentor.supports_affineview(ConvertEltype) === false
+    end
+    @testset "lazy" begin
+        @test Augmentor.supports_lazy(ConvertEltype) === true
+        @test Augmentor.supports_lazy(ConvertEltype{Float64}) === true
+        @test @inferred(Augmentor.supports_lazy(typeof(ConvertEltype(Gray)))) === true
+        let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray), rgb_rect))
+            @test typeof(img) <: ReadonlyMappedArray{Gray{N0f8},2}
+            @test img == convert.(Gray, rgb_rect)
+        end
+        let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray{Float32}), rgb_rect))
+            @test typeof(img) <: ReadonlyMappedArray{Gray{Float32},2}
+            @test img == convert.(Gray{Float32}, rgb_rect)
+        end
+        let img = @inferred(Augmentor.applylazy(ConvertEltype(Float32), checkers))
+            @test typeof(img) <: ReadonlyMappedArray{Float32,2}
+            @test img == convert(Array{Float32}, checkers)
+        end
+        let img = @inferred(Augmentor.applylazy(ConvertEltype(RGB), checkers))
+            @test typeof(img) <: ReadonlyMappedArray{RGB{N0f8},2}
+            @test img == convert.(RGB, checkers)
+        end
+    end
+    @testset "view" begin
+        @test Augmentor.supports_view(ConvertEltype) === false
+    end
+    @testset "stepview" begin
+        @test Augmentor.supports_stepview(ConvertEltype) === false
+    end
+    @testset "permute" begin
+        @test Augmentor.supports_permute(ConvertEltype) === false
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, FixedPointNumbers, TestImages, IdentityRanges, Base.Test
+using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, FixedPointNumbers, TestImages, IdentityRanges, MappedArrays, Base.Test
 using ImageInTerminal
 
 # check for ambiguities
@@ -35,6 +35,7 @@ rgb_rect = rand(RGB{N0f8}, 2, 3)
 tests = [
     "tst_utils.jl",
     "operations/tst_channels.jl",
+    "operations/tst_convert.jl",
     "operations/tst_noop.jl",
     "operations/tst_cache.jl",
     "operations/tst_rotation.jl",


### PR DESCRIPTION
This allows for things like converting a `RGB` image to a `Gray` image, or even just to convert between `Float64` to `Float32`.


`testpattern()` | `augment(ConvertEltype(GrayA))`
---------------|-------------------
![testpatternm](https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/testpattern_small.png) | ![converteltype](https://raw.githubusercontent.com/JuliaML/FileStorage/master/Augmentor/operations/ConvertEltype.png)