### PR TITLE
`augment!` and `augmentbatch!`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # v0.2.0
 
+New functionality:
+
+- `augment!`: Use preallocated storage for the output
+
+- `augmentbatch!`: Augment a whole batch of images. Optionally
+  using multiple threads.
+
 New operations:
 
 - `ConvertEltype`: Convert the array elements to the given type

--- a/REQUIRE
+++ b/REQUIRE
@@ -10,6 +10,8 @@ StaticArrays
 OffsetArrays
 IdentityRanges
 ColorTypes 0.4
+MLDataPattern 0.1.2
+ComputationalResources 0.0.2
 ShowItLikeYouBuildIt
 FileIO
 Compat 0.17

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -13,6 +13,8 @@ using Interpolations
 using StaticArrays
 using OffsetArrays
 using IdentityRanges
+using MLDataPattern
+using ComputationalResources
 using FileIO
 using ShowItLikeYouBuildIt
 using Compat
@@ -59,6 +61,8 @@ export
     ElasticDistortion,
 
     augment,
+    augment!,
+    augmentbatch!,
 
     testpattern
 
@@ -87,5 +91,6 @@ include("operations/distortion.jl")
 include("pipeline.jl")
 include("codegen.jl")
 include("augment.jl")
+include("augmentbatch.jl")
 
 end # module

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -93,4 +93,8 @@ include("codegen.jl")
 include("augment.jl")
 include("augmentbatch.jl")
 
+function __init__()
+    rand_mutex[] = Threads.Mutex()
+end
+
 end # module

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -39,12 +39,27 @@ function augment(op::Union{AbstractPipeline,Operation})
     augment(use_testpattern(), op)
 end
 
-# --------------------------------------------------------------------
-
 @inline function _augment(img, pipeline::AbstractPipeline)
     _augment(img, operations(pipeline)...)
 end
 
 @generated function _augment(img, pipeline::Vararg{Operation})
-    Expr(:block, Expr(:meta, :inline), augment_impl(:img, pipeline))
+    Expr(:block, Expr(:meta, :inline), augment_impl(:img, pipeline, false))
 end
+
+# --------------------------------------------------------------------
+
+function augment!(out, img, pipeline::AbstractPipeline)
+    out_lazy = _augment_avoid_eager(img, pipeline)
+    copy!(match_idx(out, indices(out_lazy)), out_lazy)
+    out
+end
+
+@inline function _augment_avoid_eager(img, pipeline::AbstractPipeline)
+    _augment_avoid_eager(img, operations(pipeline)...)
+end
+
+@generated function _augment_avoid_eager(img, pipeline::Vararg{Operation})
+    Expr(:block, Expr(:meta, :inline), augment_impl(:img, pipeline, true))
+end
+

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -49,6 +49,8 @@ end
 
 # --------------------------------------------------------------------
 
+augment!(out, img, op::Operation) = augment!(out, img, (op,))
+
 function augment!(out, img, pipeline::AbstractPipeline)
     out_lazy = _augment_avoid_eager(img, pipeline)
     copy!(match_idx(out, indices(out_lazy)), out_lazy)

--- a/src/augment.jl
+++ b/src/augment.jl
@@ -49,6 +49,24 @@ end
 
 # --------------------------------------------------------------------
 
+"""
+    augment!(out, img, pipeline) -> out
+
+Apply the operations of the given `pipeline` to the image `img`
+and write the resulting image into `out`.
+
+The parameter `pipeline` can be a subtype of
+`Augmentor.Pipeline`, a tuple of `Augmentor.Operation`, or a
+single `Augmentor.Operation`
+
+```julia
+img = testpattern()
+out = similar(img)
+augment!(out, img, FlipX() |> FlipY())
+augment!(out, img, (FlipX(), FlipY()))
+augment!(out, img, FlipX())
+```
+"""
 augment!(out, img, op::Operation) = augment!(out, img, (op,))
 
 function augment!(out, img, pipeline::AbstractPipeline)
@@ -64,4 +82,3 @@ end
 @generated function _augment_avoid_eager(img, pipeline::Vararg{Operation})
     Expr(:block, Expr(:meta, :inline), augment_impl(:img, pipeline, true))
 end
-

--- a/src/augmentbatch.jl
+++ b/src/augmentbatch.jl
@@ -1,0 +1,46 @@
+_berror() = throw(ArgumentError("Number of output images must be equal to the number of input images"))
+
+imagesvector(imgs::AbstractArray) = obsview(imgs)
+@inline imagesvector(imgs::AbstractVector{<:AbstractArray}) = imgs
+
+# --------------------------------------------------------------------
+
+function augmentbatch!(
+        outs::AbstractArray,
+        imgs::AbstractArray,
+        pipeline::AbstractPipeline)
+    augmentbatch!(CPU1(), outs, imgs, pipeline)
+end
+
+function augmentbatch!(
+        r::AbstractResource,
+        outs::AbstractArray,
+        imgs::AbstractArray,
+        pipeline::AbstractPipeline)
+    augmentbatch!(r, imagesvector(outs), imagesvector(imgs), pipeline)
+    outs
+end
+
+function augmentbatch!(
+        ::CPU1,
+        outs::AbstractVector{<:AbstractArray},
+        imgs::AbstractVector{<:AbstractArray},
+        pipeline::AbstractPipeline)
+    length(outs) == length(imgs) || _berror()
+    for i in 1:length(outs)
+        augment!(outs[i], imgs[i], pipeline)
+    end
+    outs
+end
+
+function augmentbatch!(
+        ::CPUThreads,
+        outs::AbstractVector{<:AbstractArray},
+        imgs::AbstractVector{<:AbstractArray},
+        pipeline::AbstractPipeline)
+    length(outs) == length(imgs) || _berror()
+    Threads.@threads for i in 1:length(outs)
+        augment!(outs[i], imgs[i], pipeline)
+    end
+    outs
+end

--- a/src/augmentbatch.jl
+++ b/src/augmentbatch.jl
@@ -8,7 +8,7 @@ imagesvector(imgs::AbstractArray) = obsview(imgs)
 function augmentbatch!(
         outs::AbstractArray,
         imgs::AbstractArray,
-        pipeline::AbstractPipeline)
+        pipeline)
     augmentbatch!(CPU1(), outs, imgs, pipeline)
 end
 
@@ -16,7 +16,7 @@ function augmentbatch!(
         r::AbstractResource,
         outs::AbstractArray,
         imgs::AbstractArray,
-        pipeline::AbstractPipeline)
+        pipeline)
     augmentbatch!(r, imagesvector(outs), imagesvector(imgs), pipeline)
     outs
 end
@@ -25,7 +25,7 @@ function augmentbatch!(
         ::CPU1,
         outs::AbstractVector{<:AbstractArray},
         imgs::AbstractVector{<:AbstractArray},
-        pipeline::AbstractPipeline)
+        pipeline)
     length(outs) == length(imgs) || _berror()
     for i in 1:length(outs)
         augment!(outs[i], imgs[i], pipeline)
@@ -37,7 +37,7 @@ function augmentbatch!(
         ::CPUThreads,
         outs::AbstractVector{<:AbstractArray},
         imgs::AbstractVector{<:AbstractArray},
-        pipeline::AbstractPipeline)
+        pipeline)
     length(outs) == length(imgs) || _berror()
     Threads.@threads for i in 1:length(outs)
         augment!(outs[i], imgs[i], pipeline)

--- a/src/augmentbatch.jl
+++ b/src/augmentbatch.jl
@@ -5,6 +5,28 @@ imagesvector(imgs::AbstractArray) = obsview(imgs)
 
 # --------------------------------------------------------------------
 
+"""
+    augmentbatch!([resource], outs, imgs, pipeline) -> outs
+
+Apply the operations of the given `pipeline` to the images in
+`imgs` and write the resulting images into `outs`.
+
+Both `outs` and `imgs` have to contain the same number of images.
+Each of the two variables can either be in the form of a higher
+dimensional array for which the last dimension enumerates the
+individual images, or alternatively in the form of a vector of
+arrays, for which each vector element denotes an image.
+
+The parameter `pipeline` can be a subtype of
+`Augmentor.Pipeline`, a tuple of `Augmentor.Operation`, or a
+single `Augmentor.Operation`.
+
+The optional first parameter `resource` can either be `CPU1()`
+(default) or `CPUThreads()`. In the case of the later the images
+will be augmented in parallel. For this to make sense make sure
+that the environment variable `JULIA_NUM_THREADS` is set to a
+reasonable number so that `Threads.nthreads()` is greater than 1.
+"""
 function augmentbatch!(
         outs::AbstractArray,
         imgs::AbstractArray,

--- a/src/codegen.jl
+++ b/src/codegen.jl
@@ -1,9 +1,11 @@
 """
-    seek_connected(f, N::Int, head::DataType, tail::Tuple) -> (N, seq)
+    seek_connected(f, N::Int, head::DataType, tail::Tuple) -> (N, remainder)
 
 Recursively scan a tuple of `DataType` (split into its `head` and
-`tail`) to compute the uninterrupted sequence `seq` of adjacent
-operations (and its length `N`) where the predicate `f` is true.
+`tail`) to compute the length `N` of the uninterrupted sequence
+of adjacent operations where the predicate `f` is true.
+Additionally the `remainder` of the tuple (without that sequence)
+is also returned.
 """
 @inline function seek_connected(f, N::Int, head::Type{<:Operation}, tail::Tuple)
     if f(head)
@@ -32,51 +34,56 @@ end
 
 # --------------------------------------------------------------------
 
-function augment_impl(var_offset::Int, op_offset::Int, pipeline::Tuple)
-    augment_impl(var_offset, op_offset, first(pipeline), Base.tail(pipeline))
+function augment_impl(var_offset::Int, op_offset::Int, pipeline::Tuple, args...)
+    augment_impl(var_offset, op_offset, first(pipeline), Base.tail(pipeline), args...)
 end
 
-function augment_impl(var_offset::Int, op_offset::Int, pipeline::Tuple{})
+function augment_impl(var_offset::Int, op_offset::Int, pipeline::Tuple{}, args...)
     :($(Symbol(:img_, var_offset)))
 end
 
-function augment_impl(var_offset::Int, op_offset::Int, head, tail::NTuple{N,DataType}) where N
+function augment_impl(var_offset::Int, op_offset::Int, head::DataType, tail::NTuple{N,DataType}, avoid_eager = false) where N
     var_in  = Symbol(:img_, var_offset)
     var_out = Symbol(:img_, var_offset+1)
     if supports_lazy(head, tail)
-        num_affine, rest_affine = uses_affinemap(head, tail) ? seek_connected(uses_affinemap, 0, head, tail) : (0, nothing)
+        # If reached there are at least two adjacent lazy operations
+        num_affine, after_affine = uses_affinemap(head, tail) ? seek_connected(uses_affinemap, 0, head, tail) : (0, nothing)
         num_special, _ = seek_connected(x->(supports_permute(x)||supports_view(x)||supports_stepview(x)), 0, head, tail)
-        num_lazy, rest_lazy = seek_connected(supports_lazy, 0, head, tail)
+        num_lazy, after_lazy = seek_connected(supports_lazy, 0, head, tail)
         if num_special >= num_affine
             quote
                 $var_out = unroll_applylazy($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_lazy-1)...)), $var_in)
-                $(augment_impl(var_offset+1, op_offset+num_lazy, rest_lazy))
+                $(augment_impl(var_offset+1, op_offset+num_lazy, after_lazy, avoid_eager))
             end
         else
             quote
                 $var_out = unroll_applyaffine($(Expr(:tuple, (:(pipeline[$i]) for i in op_offset:op_offset+num_affine-1)...)), $var_in)
-                $(augment_impl(var_offset+1, op_offset+num_affine, rest_affine))
+                $(augment_impl(var_offset+1, op_offset+num_affine, after_affine, avoid_eager))
             end
         end
     else
-        if length(tail) == 0 || supports_eager(head) || !supports_lazy(head)
+        # At most "head" is lazy (i.e. tail[1] is surely not).
+        # Unless "avoid_eager==true" we prefer using "applyeager" in
+        # this case because there is no neighbour synergy and we
+        # assume "applyeager" is more efficient.
+        if !supports_lazy(head) || (!avoid_eager && (length(tail) == 0 || supports_eager(head)))
             quote
                 $var_out = applyeager(pipeline[$op_offset], $var_in)
-                $(augment_impl(var_offset+1, op_offset+1, tail))
+                $(augment_impl(var_offset+1, op_offset+1, tail, avoid_eager))
             end
-        else # use lazy because there is no special eager implementation
+        else
             quote
-                $var_out = unroll_applylazy(pipeline[$op_offset], $var_in)
-                $(augment_impl(var_offset+1, op_offset+1, tail))
+                $var_out = applylazy(pipeline[$op_offset], $var_in)
+                $(augment_impl(var_offset+1, op_offset+1, tail, avoid_eager))
             end
         end
     end
 end
 
-function augment_impl(varname, pipeline::NTuple{N,DataType}) where N
+function augment_impl(varname::Symbol, pipeline::NTuple{N,DataType}, args...) where N
     quote
         img_1 = $varname
-        $(augment_impl(1, 1, pipeline))
+        $(augment_impl(1, 1, pipeline, args...))
     end
 end
 
@@ -102,8 +109,8 @@ end
 #       end
 #   end
 
-function augment_impl(pipeline::AbstractPipeline)
-    augment_impl(:input_image, map(typeof, operations(pipeline)))
+function augment_impl(pipeline::AbstractPipeline; avoid_eager = false)
+    augment_impl(:input_image, map(typeof, operations(pipeline)), avoid_eager)
 end
 
-augment_impl(op::Operation) = augment_impl((op,))
+augment_impl(op::Operation; kw...) = augment_impl((op,); kw...)

--- a/src/distortionfields.jl
+++ b/src/distortionfields.jl
@@ -18,10 +18,10 @@ end
 function uniform_field(gridheight::Int, gridwidth::Int, scale, border, normalize)
     A = if !border
         @assert gridwidth > 2 && gridheight > 2
-        _2dborder!(rand(2, gridheight, gridwidth), .5)
+        _2dborder!(safe_rand(2, gridheight, gridwidth), .5)
     else
         @assert gridwidth > 0 && gridheight > 0
-        rand(2, gridheight, gridwidth)
+        safe_rand(2, gridheight, gridwidth)
     end::Array{Float64,3}
     broadcast!(*, A, A, 2.)
     broadcast!(-, A, A, 1.)

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -86,10 +86,6 @@ CacheImage(buffer::AbstractArray) = CacheImageInto(buffer)
 
 @inline supports_lazy(::Type{<:CacheImageInto}) = true
 
-@inline match_idx(buffer::AbstractArray, inds::Tuple) = buffer
-@inline match_idx(buffer::Array, inds::NTuple{N,UnitRange}) where {N} =
-    OffsetArray(buffer, inds)
-
 applyeager(op::CacheImageInto, img) = applylazy(op, img)
 
 function applylazy(op::CacheImageInto, img)

--- a/src/operations/crop.jl
+++ b/src/operations/crop.jl
@@ -480,12 +480,12 @@ function rcropratio_indices(op::RCropRatio, img::AbstractMatrix)
     elseif nw < w
         x_max = w - nw + 1
         @assert x_max > 0
-        x = rand(1:x_max)
+        x = safe_rand(1:x_max)
         1:h, x:(x+nw-1)
     elseif nh < h
         y_max = h - nh + 1
         @assert y_max > 0
-        y = rand(1:y_max)
+        y = safe_rand(1:y_max)
         y:(y+nh-1), 1:w
     else
         error("unreachable code reached")

--- a/src/operations/either.jl
+++ b/src/operations/either.jl
@@ -158,7 +158,7 @@ end
 
 function toaffinemap(op::Either, img)
     supports_affine(typeof(op)) || throw(MethodError(toaffinemap, (op, img)))
-    p = rand()
+    p = safe_rand()
     for (i, p_i) in enumerate(op.cum_chances)
         if p <= p_i
             return toaffinemap_common(op.operations[i], img)
@@ -179,7 +179,7 @@ for KIND in (:eager, :permute, :view, :stepview, :affine, :affineview)
     APP = startswith(String(KIND),"affine") ? Symbol(FUN, :_common) : FUN
     @eval function ($FUN)(op::Either, img)
         ($SUP)(typeof(op)) || throw(MethodError($FUN, (op, img)))
-        p = rand()
+        p = safe_rand()
         for (i, p_i) in enumerate(op.cum_chances)
             if p <= p_i
                 return ($APP)(op.operations[i], img)

--- a/src/operations/rotation.jl
+++ b/src/operations/rotation.jl
@@ -321,7 +321,7 @@ Rotate(degree::Real) = Rotate(degree:degree)
 @inline supports_eager(::Type{<:Rotate}) = false
 
 function toaffinemap(op::Rotate, img::AbstractMatrix)
-    recenter(RotMatrix(deg2rad(Float64(rand(op.degree)))), center(img))
+    recenter(RotMatrix(deg2rad(Float64(safe_rand(op.degree)))), center(img))
 end
 
 function Base.show(io::IO, op::Rotate)

--- a/src/operations/rotation.jl
+++ b/src/operations/rotation.jl
@@ -69,13 +69,13 @@ function applypermute(::Rotate90, img::AbstractMatrix{T}) where T
     view(perm_img, reverse(idx[2]), idx[1])
 end
 
-function applypermute(::Rotate90, sub::SubArray{T,2,IT}) where {T,IT<:PermutedDimsArray{T,2,(2,1)}}
+function applypermute(::Rotate90, sub::SubArray{T,2,IT,<:NTuple{2,Range}}) where {T,IT<:PermutedDimsArray{T,2,(2,1)}}
     idx = map(StepRange, sub.indexes)
     img = parent(parent(sub))
     view(img, reverse(idx[2]), idx[1])
 end
 
-function applypermute(::Rotate90, sub::SubArray{T,2}) where T
+function applypermute(::Rotate90, sub::SubArray{T,2,IT,<:NTuple{2,Range}}) where {T,IT}
     idx = map(StepRange, sub.indexes)
     img = parent(sub)
     perm_img = PermutedDimsArray{T,2,(2,1),(2,1),typeof(img)}(img)
@@ -223,13 +223,13 @@ function applypermute(::Rotate270, img::AbstractMatrix{T}) where T
     view(perm_img, idx[2], reverse(idx[1]))
 end
 
-function applypermute(::Rotate270, sub::SubArray{T,2,IT}) where {T,IT<:PermutedDimsArray{T,2,(2,1)}}
+function applypermute(::Rotate270, sub::SubArray{T,2,IT,<:NTuple{2,Range}}) where {T,IT<:PermutedDimsArray{T,2,(2,1)}}
     idx = map(StepRange, sub.indexes)
     img = parent(parent(sub))
     view(img, idx[2], reverse(idx[1]))
 end
 
-function applypermute(::Rotate270, sub::SubArray{T,2}) where T
+function applypermute(::Rotate270, sub::SubArray{T,2,IT,<:NTuple{2,Range}}) where {T,IT}
     idx = map(StepRange, sub.indexes)
     img = parent(sub)
     perm_img = PermutedDimsArray{T,2,(2,1),(2,1),typeof(img)}(img)

--- a/src/operations/scale.jl
+++ b/src/operations/scale.jl
@@ -74,13 +74,13 @@ Scale() = throw(MethodError(Scale, ()))
 Scale(::Tuple{}) = throw(MethodError(Scale, ((),)))
 Scale(factors...) = Scale(factors)
 Scale(factor::Union{AbstractVector,Real}) = Scale((factor, factor))
-Scale(factors::NTuple{N,Any}) where {N} = Scale(map(_vectorize, factors))
+Scale(factors::NTuple{N,Any}) where {N} = Scale(map(vectorize, factors))
 Scale(factors::NTuple{N,Range}) where {N} = Scale{N}(promote(factors...))
 function Scale(factors::NTuple{N,AbstractVector}) where N
     Scale{N}(map(Vector{Float64}, factors))
 end
 function (::Type{Scale{N}})(factors::NTuple{N,Any}) where N
-    Scale(map(_vectorize, factors))
+    Scale(map(vectorize, factors))
 end
 
 @inline supports_eager(::Type{<:Scale}) = false

--- a/src/operations/scale.jl
+++ b/src/operations/scale.jl
@@ -86,7 +86,7 @@ end
 @inline supports_eager(::Type{<:Scale}) = false
 
 function toaffinemap(op::Scale{2}, img::AbstractMatrix)
-    idx = rand(1:length(op.factors[1]))
+    idx = safe_rand(1:length(op.factors[1]))
     @inbounds tfm = recenter(@SMatrix([Float64(op.factors[1][idx]) 0.; 0. Float64(op.factors[2][idx])]), center(img))
     tfm
 end

--- a/src/operations/shear.jl
+++ b/src/operations/shear.jl
@@ -63,7 +63,7 @@ ShearX(degree::Real) = ShearX(degree:degree)
 @inline supports_eager(::Type{<:ShearX}) = false
 
 function toaffinemap(op::ShearX, img::AbstractMatrix)
-    angle = deg2rad(Float64(rand(op.degree)))
+    angle = deg2rad(Float64(safe_rand(op.degree)))
     recenter(@SMatrix([1. 0.; tan(-angle) 1.]), center(img))
 end
 
@@ -147,7 +147,7 @@ ShearY(degree::Real) = ShearY(degree:degree)
 @inline supports_eager(::Type{<:ShearY}) = false
 
 function toaffinemap(op::ShearY, img::AbstractMatrix)
-    angle = deg2rad(Float64(rand(op.degree)))
+    angle = deg2rad(Float64(safe_rand(op.degree)))
     recenter(@SMatrix([1. tan(-angle); 0. 1.]), center(img))
 end
 

--- a/src/operations/zoom.jl
+++ b/src/operations/zoom.jl
@@ -91,7 +91,7 @@ end
 @inline supports_eager(::Type{<:Zoom}) = false
 
 function toaffinemap(op::Zoom{2}, img::AbstractMatrix)
-    idx = rand(1:length(op.factors[1]))
+    idx = safe_rand(1:length(op.factors[1]))
     @inbounds tfm = recenter(@SMatrix([Float64(op.factors[1][idx]) 0.; 0. Float64(op.factors[2][idx])]), center(img))
     tfm
 end

--- a/src/operations/zoom.jl
+++ b/src/operations/zoom.jl
@@ -78,13 +78,13 @@ Zoom() = throw(MethodError(Zoom, ()))
 Zoom(::Tuple{}) = throw(MethodError(Zoom, ((),)))
 Zoom(factors...) = Zoom(factors)
 Zoom(factor::Union{AbstractVector,Real}) = Zoom((factor, factor))
-Zoom(factors::NTuple{N,Any}) where {N} = Zoom(map(_vectorize, factors))
+Zoom(factors::NTuple{N,Any}) where {N} = Zoom(map(vectorize, factors))
 Zoom(factors::NTuple{N,Range}) where {N} = Zoom{N}(promote(factors...))
 function Zoom(factors::NTuple{N,AbstractVector}) where N
     Zoom{N}(map(Vector{Float64}, factors))
 end
 function (::Type{Zoom{N}})(factors::NTuple{N,Any}) where N
-    Zoom(map(_vectorize, factors))
+    Zoom(map(vectorize, factors))
 end
 
 @inline supports_affineview(::Type{<:Zoom}) = true
@@ -120,7 +120,7 @@ end
 
 function Base.show(io::IO, op::Zoom{N}) where N
     if get(io, :compact, false)
-        str = join(map(t->join(_round(t,2),"×"), collect(zip(op.factors...))), ", ")
+        str = join(map(t->join(round_if_float(t,2),"×"), collect(zip(op.factors...))), ", ")
         if length(op.factors[1]) == 1
             print(io, "Zoom by $(str)")
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -27,6 +27,12 @@ end
 
 # --------------------------------------------------------------------
 
+@inline match_idx(buffer::AbstractArray, inds::Tuple) = buffer
+@inline match_idx(buffer::Union{Array,SubArray}, inds::NTuple{N,UnitRange}) where {N} =
+    OffsetArray(buffer, inds)
+
+# --------------------------------------------------------------------
+
 function indirect_indices(::Tuple{}, ::Tuple{})
     throw(MethodError(indirect_indices, ((),())))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, FixedPointNumbers, TestImages, IdentityRanges, MappedArrays, Base.Test
+using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, FixedPointNumbers, TestImages, IdentityRanges, MappedArrays, ComputationalResources, MLDataPattern, Base.Test
 using ImageInTerminal
 
 # check for ambiguities

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,10 @@
+# Things that needs to be tested
+# [x] Utility functions work properly and type stable
+# [x] Individual operations do what they should
+# [x] Individual operations are always type stable
+# [x] Lazy Either works correctly and type stable
+# [x] Operations accept AbstractArray as input (esp. Array and SubArray)
+
 using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, FixedPointNumbers, TestImages, IdentityRanges, MappedArrays, ComputationalResources, MLDataPattern, Base.Test
 using ImageInTerminal
 
@@ -26,6 +33,9 @@ function str_showconst(obj)
 end
 
 camera = testimage("cameraman")
+cameras = similar(camera, size(camera)..., 2)
+copy!(view(cameras,:,:,1), camera)
+copy!(view(cameras,:,:,2), camera)
 square = Gray{N0f8}[0.1 0.2 0.3; 0.4 0.5 0.6; 0.7 0.6 0.9]
 square2 = rand(Gray{N0f8}, 4, 4)
 rect = Gray{N0f8}[0.1 0.2 0.3; 0.4 0.5 0.6]
@@ -50,6 +60,7 @@ tests = [
     "tst_operations.jl",
     "tst_pipeline.jl",
     "tst_augment.jl",
+    "tst_augmentbatch.jl",
     "tst_distortedview.jl",
 ]
 

--- a/test/tst_augment.jl
+++ b/test/tst_augment.jl
@@ -69,6 +69,7 @@ end
         img = @inferred Augmentor._augment(rect, pl)
         @test typeof(img) <: Array
         @test typeof(img) == typeof(@inferred(augment(rect, Rotate90())))
+        @test typeof(img) == typeof(@inferred(augment(rect, (Rotate90(),))))
         @test eltype(img) <: eltype(rect)
         @test img == rotl90(rect)
         out = similar(img)

--- a/test/tst_augment.jl
+++ b/test/tst_augment.jl
@@ -64,21 +64,19 @@ end
 # --------------------------------------------------------------------
 
 @testset "single op" begin
-    img = @inferred Augmentor._augment(rect, Augmentor.ImmutablePipeline(Rotate90()))
-    @test typeof(img) <: Array
-    @test typeof(img) == typeof(@inferred(augment(rect, (Rotate90(),))))
-    @test eltype(img) <: eltype(rect)
-    @test img == rotl90(rect)
-    img = @inferred Augmentor._augment(rect, (Rotate90(),))
-    @test typeof(img) <: Array
-    @test typeof(img) == typeof(@inferred(augment(rect, (Rotate90(),))))
-    @test eltype(img) <: eltype(rect)
-    @test img == rotl90(rect)
-    img = @inferred Augmentor._augment(square, (Rotate(90),))
-    @test typeof(img) <: Array
-    @test typeof(img) == typeof(@inferred(augment(square, (Rotate(90),))))
-    @test eltype(img) <: eltype(square)
-    @test img == rotl90(square)
+    @test_throws BoundsError augment!(rand(2,2), rect, Rotate90())
+    for pl in (Augmentor.ImmutablePipeline(Rotate90()), (Rotate90(),))
+        img = @inferred Augmentor._augment(rect, pl)
+        @test typeof(img) <: Array
+        @test typeof(img) == typeof(@inferred(augment(rect, Rotate90())))
+        @test eltype(img) <: eltype(rect)
+        @test img == rotl90(rect)
+        out = similar(img)
+        @test @inferred(augment!(out, rect, pl)) == img
+        out = similar(img)
+        @test @inferred(augment!(out, rect, Rotate90())) == img
+        @test_throws BoundsError augment!(rand(2,2), rect, pl)
+    end
 end
 
 ops = Augmentor.ImmutablePipeline(Rotate(90),Rotate(-90)) # forces affine
@@ -162,6 +160,10 @@ ops = (Rotate180(),Crop(5:200,200:500),Rotate90(1),Crop(1:250, 1:150))
     @test typeof(img) <: Array
     @test eltype(img) <: eltype(camera)
     @test_reference "rot_crop_either_crop" img
+    out = similar(img)
+    @test @inferred(augment!(out, camera, ops)) === out
+    @test_reference "rot_crop_either_crop" out
+    @test @allocated(augment!(out, camera, ops)) < @allocated(augment(camera, ops))
 end
 
 ops = Augmentor.ImmutablePipeline(Rotate180(),Crop(5:200,200:500),Rotate90(),Crop(50:300, 50:195))
@@ -175,6 +177,10 @@ ops = Augmentor.ImmutablePipeline(Rotate180(),Crop(5:200,200:500),Rotate90(),Cro
     @test typeof(img) <: Array
     @test eltype(img) <: eltype(camera)
     @test_reference "rot_crop_rot_crop" img
+    out = similar(img)
+    @test @inferred(augment!(out, camera, ops)) === out
+    @test_reference "rot_crop_rot_crop" out
+    @test @allocated(augment!(out, camera, ops)) < @allocated(augment(camera, ops))
 end
 
 ops = (Rotate180(),Crop(5:200,200:500),Rotate90(),Crop(50:300, 50:195),Resize(25,15))
@@ -191,6 +197,10 @@ ops = (Rotate180(),Crop(5:200,200:500),Rotate90(),Crop(50:300, 50:195),Resize(25
     @test typeof(img) <: Array
     @test eltype(img) <: eltype(camera)
     @test_reference "rot_crop_rot_crop_resize" img
+    out = similar(img)
+    @test @inferred(augment!(out, camera, ops)) === out
+    @test_reference "rot_crop_rot_crop_resize" out
+    @test @allocated(augment!(out, camera, ops)) < @allocated(augment(camera, ops))
 end
 
 ops = (Rotate(45),CropNative(1:512,1:512))

--- a/test/tst_augmentbatch.jl
+++ b/test/tst_augmentbatch.jl
@@ -1,0 +1,66 @@
+
+ops = (Rotate180(),Crop(5:200,200:500),Rotate90(1),Crop(1:250, 1:150))
+@testset "$(str_showcompact(ops))" begin
+    @test_throws ArgumentError augmentbatch!(similar(camera, 250, 150, 3), cameras, ops)
+    @test_throws DimensionMismatch augmentbatch!(similar(camera, 250, 140, 2), cameras, ops)
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(out, cameras, ops)) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(out, cameras, Augmentor.ImmutablePipeline(ops))) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(out, collect.(obsview(cameras)), ops)) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    outs = [similar(camera, 250, 150), similar(camera, 250, 150)]
+    @test @inferred(augmentbatch!(outs, cameras, ops)) === outs
+    @test typeof(outs) <: Vector
+    @test eltype(outs) <: Array{eltype(camera)}
+    @test_reference "rot_crop_either_crop" outs[1]
+    @test_reference "rot_crop_either_crop" outs[2]
+end
+
+@testset "Multithreaded: $(str_showcompact(ops))" begin
+    @test_throws ArgumentError augmentbatch!(CPUThreads(), similar(camera, 250, 150, 3), cameras, ops)
+    # doesn't work because exception is thrown in thread
+    # @test_throws DimensionMismatch augmentbatch!(CPUThreads(), similar(camera, 250, 140, 2), cameras, ops)
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(CPUThreads(), out, cameras, ops)) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(CPUThreads(), out, cameras, Augmentor.ImmutablePipeline(ops))) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    out = similar(camera, 250, 150, 2)
+    @test @inferred(augmentbatch!(CPUThreads(), out, collect.(obsview(cameras)), ops)) === out
+    @test typeof(out) <: Array
+    @test eltype(out) <: eltype(camera)
+    @test_reference "rot_crop_either_crop" out[:,:,1]
+    @test_reference "rot_crop_either_crop" out[:,:,2]
+    outs = [similar(camera, 250, 150), similar(camera, 250, 150)]
+    @test @inferred(augmentbatch!(CPUThreads(), outs, cameras, ops)) === outs
+    @test typeof(outs) <: Vector
+    @test eltype(outs) <: Array{eltype(camera)}
+    @test_reference "rot_crop_either_crop" outs[1]
+    @test_reference "rot_crop_either_crop" outs[2]
+end
+
+ops = Rotate90()
+@testset "$(str_showcompact(ops))" begin
+    out = similar(camera, 512, 512, 2)
+    @test @inferred(augmentbatch!(out, cameras, ops)) === out
+end


### PR DESCRIPTION
This allows to augment a full batch at once and store the result into a single higher-dim array (e.g. HxWxN). It also allows for multithreaded use where the images of a batch are processed in parallel. To be able to do that safely I introduced a Mutex to protect access to the global RNG.