### PR TITLE
wrap applyeager with plain_array

### DIFF
--- a/src/operation.jl
+++ b/src/operation.jl
@@ -63,9 +63,7 @@ for FUN in (:applyeager, :applylazy, :applypermute,
 end
 
 function applyeager(op::Operation, img::AbstractArray, param)
-    # TODO: we don't need wrappers for eager mode, so we might want to
-    # add plain_array to it as well for the sake of simplicity
-    contiguous(applylazy(op, img, param))
+    plain_array(applylazy(op, img, param))
 end
 
 function applyaffineview(op::Operation, img::AbstractArray, param)

--- a/src/operations/cache.jl
+++ b/src/operations/cache.jl
@@ -53,7 +53,7 @@ pl = ElasticDistortion(3,3) |> zeros(20,20) |> Rotate(-10:10)
 """
 struct CacheImage <: ImageOperation end
 
-applyeager(op::CacheImage, img::AbstractArray, param) = contiguous(img)
+applyeager(op::CacheImage, img::AbstractArray, param) = plain_array(img)
 
 function showconstruction(io::IO, op::CacheImage)
     print(io, typeof(op).name.name, "()")
@@ -84,14 +84,15 @@ CacheImage(buffers::NTuple{N,AbstractArray}) where {N} = CacheImageInto(buffers)
 
 @inline supports_lazy(::Type{<:CacheImageInto}) = true
 
-applyeager(op::CacheImageInto, img::AbstractArray, param) = applylazy(op, img)
-applyeager(op::CacheImageInto, img::Tuple) = applylazy(op, img)
+applyeager(op::CacheImageInto, img::AbstractArray, param) = plain_array(applylazy(op, img))
+applyeager(op::CacheImageInto, img::Tuple) = plain_array(applylazy(op, img))
 
 function applylazy(op::CacheImageInto, img::Tuple)
     throw(ArgumentError("Operation $(op) not compatiable with given image(s) ($(summary(img))). This can happen if the amount of images does not match the amount of buffers in the operation"))
 end
 
 function applylazy(op::CacheImageInto{<:AbstractArray}, img::AbstractArray, param)
+    # TODO: don't copy data if img is memory contiguous
     copyto!(match_idx(op.buffer, axes(img)), img)
 end
 

--- a/src/operations/convert.jl
+++ b/src/operations/convert.jl
@@ -52,7 +52,7 @@ end
 @inline supports_lazy(::Type{<:ConvertEltype}) = true
 
 function applyeager(op::ConvertEltype{T}, img::AbstractArray, param) where T
-    contiguous(convert(AbstractArray{T}, img))
+    plain_array(convert(AbstractArray{T}, img))
 end
 
 function applylazy(op::ConvertEltype{T}, img::AbstractArray, param) where T

--- a/src/operations/dims.jl
+++ b/src/operations/dims.jl
@@ -68,7 +68,7 @@ PermuteDims(perm::Vararg{Int,N}) where {N} = PermuteDims{N,perm,invperm(perm)}()
 @inline supports_lazy(::Type{<:PermuteDims}) = true
 
 function applyeager(op::PermuteDims{N,perm}, img::AbstractArray{T,N}, param) where {T,N,perm}
-    permutedims(img, perm)
+    plain_array(permutedims(img, perm))
 end
 
 function applylazy(op::PermuteDims{N,perm,iperm}, img::AbstractArray{T,N}, param) where {T,N,perm,iperm}

--- a/src/operations/mapfun.jl
+++ b/src/operations/mapfun.jl
@@ -51,7 +51,7 @@ end
 @inline supports_lazy(::Type{<:MapFun}) = true
 
 function applyeager(op::MapFun, img::AbstractArray, param)
-    contiguous(map(op.fun, img))
+    plain_array(map(op.fun, img))
 end
 
 function applylazy(op::MapFun, img::AbstractArray, param)
@@ -130,7 +130,7 @@ end
 
 function applyeager(op::AggregateThenMapFun, img::AbstractArray, param)
     agg = op.aggfun(img)
-    contiguous(map(x -> op.mapfun(x, agg), img))
+    plain_array(map(x -> op.mapfun(x, agg), img))
 end
 
 function applylazy(op::AggregateThenMapFun, img::AbstractArray, param)

--- a/src/operations/noop.jl
+++ b/src/operations/noop.jl
@@ -15,7 +15,7 @@ struct NoOp <: AffineOperation end
 
 # TODO: implement method for n-dim arrays
 toaffinemap(::NoOp, img::AbstractMatrix) = AffineMap(@SMatrix([1. 0; 0 1.]), @SVector([0.,0.]))
-applyeager(::NoOp, img::AbstractArray, param) = contiguous(img)
+applyeager(::NoOp, img::AbstractArray, param) = plain_array(img)
 applylazy(::NoOp, img::AbstractArray, param) = img
 
 function applyview(::NoOp, img::AbstractArray, param)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -24,6 +24,8 @@ Return a memory contiguous array for better performance.
 
 Data copy only happens when necessary. For example, views returned by `view`,
 `permuteddimsview` are such cases.
+
+See also: [`plain_array`](@ref), [`plain_axes`](@ref)
 """
 @inline contiguous(A::OffsetArray) = A
 @inline contiguous(A::Array) = A
@@ -39,8 +41,20 @@ Data copy only happens when necessary. For example, views returned by `view`,
 @inline _plain_array(A::SArray) = A
 @inline _plain_array(A::MArray) = A
 @inline _plain_array(A::Tuple) = map(_plain_array, A)
-# avoid recursion
-@inline plain_array(A) = _plain_array(contiguous(A))
+
+"""
+    plain_array(A::AbstractArray)
+    plain_array(A::Tuple)
+
+Return a memory contiguous plain array for better performance.
+A plain array is either an `Array` or a `StaticArray`.
+
+Data copy only happens when necessary. For example, views returned by `view`,
+`permuteddimsview` are such cases.
+
+See also: [`contiguous`](@ref), [`plain_axes`](@ref)
+"""
+@inline plain_array(A) = _plain_array(contiguous(A)) # avoid recursion
 
 # --------------------------------------------------------------------
 
@@ -48,6 +62,8 @@ Data copy only happens when necessary. For example, views returned by `view`,
     plain_axes(A::AbstractArray)
 
 Generate a 1-based array from `A` without data copy.
+
+See also: [`contiguous`](@ref), [`plain_array`](@ref)
 """
 @inline plain_axes(A::Array) = A
 @inline plain_axes(A::OffsetArray) = parent(A)

--- a/test/operations/tst_cache.jl
+++ b/test/operations/tst_cache.jl
@@ -20,15 +20,17 @@
     # Identidy ranges
     v = view(square, IdentityRange(1:3), IdentityRange(1:3))
     img = @inferred Augmentor.applyeager(CacheImage(), v)
-    @test typeof(img) <: OffsetArray
+    @test typeof(img) <: Array
     @test eltype(img) == eltype(v)
-    @test img == OffsetArray(square, 0, 0)
+    @test img !== square
+    @test img == square
     # Affine
     v = Augmentor.prepareaffine(square)
     img = @inferred Augmentor.applyeager(CacheImage(), v)
-    @test typeof(img) <: OffsetArray
+    @test typeof(img) <: Array
     @test eltype(img) == eltype(v)
-    @test img == OffsetArray(square, 0, 0)
+    @test img !== square
+    @test img == square
     # Array and SubArray
     v = view(square, :, :)
     tmp,img = @inferred Augmentor.applyeager(CacheImage(), (square,v))
@@ -39,8 +41,8 @@
     @test img == square
     # OffsetArray
     o = OffsetArray(square, (-1,2))
-    @test @inferred(Augmentor.applyeager(CacheImage(),o)) === o
-    @test @inferred(Augmentor.applyeager(CacheImage(),(o,square))) === (o,square)
+    @test @inferred(Augmentor.applyeager(CacheImage(),o)) === parent(o)
+    @test @inferred(Augmentor.applyeager(CacheImage(),(o,square))) === (parent(o),square)
 
     @test Augmentor.supports_eager(CacheImage) === true
     @test Augmentor.supports_lazy(CacheImage) === false
@@ -83,7 +85,7 @@ end
         v = Augmentor.applylazy(Resize(2,3), camera)
         res = @inferred Augmentor.applyeager(op, v)
         @test res == v
-        @test typeof(res) <: OffsetArray
+        @test typeof(res) <: Array
         @test parent(res) === op.buffer
 
         res = @inferred Augmentor.applyeager(op, rect)
@@ -130,7 +132,7 @@ end
         @test buf1 != square
         @test buf2 != rgb_rect
         @test res == (v1, v2)
-        @test typeof(res) <: NTuple{2,OffsetArray}
+        @test typeof(res) <: NTuple{2, Array}
         @test parent.(res) === (op.buffer[1], op.buffer[2])
 
         @test_throws BoundsError Augmentor.applyeager(op, (camera,buf1))

--- a/test/operations/tst_channels.jl
+++ b/test/operations/tst_channels.jl
@@ -137,7 +137,7 @@ end
             @testset "special case that simplifies" begin
                 res = @inferred(Augmentor.applyeager(CombineChannels(Gray), reshape(channelview(Augmentor.prepareaffine(rect)), 1, 2, 3)))
                 @test collect(res) == rect
-                @test typeof(res) <: OffsetArray{Gray{N0f8}}
+                @test typeof(res) <: Array{Gray{N0f8}}
             end
             for (img_in, img_out) in imgs
                 res = @inferred(Augmentor.applyeager(CombineChannels(Gray), img_in))

--- a/test/operations/tst_convert.jl
+++ b/test/operations/tst_convert.jl
@@ -19,27 +19,26 @@
     @testset "eager" begin
         @test Augmentor.supports_eager(ConvertEltype) === true
         @test Augmentor.supports_eager(ConvertEltype{Float64}) === true
-        res1 = convert(Array{Gray{Float32}}, rect)
-        res1a = OffsetArray(res1, 0, 0)
-        res1b = OffsetArray(res1, -2, -1)
+        img_out = convert(Array{Gray{Float32}}, rect)
         imgs = [
-            (Float32, rect, Float32.(res1)),
-            (Float32, OffsetArray(rect, -2, -1), Float32.(res1b)),
-            (Gray{Float32}, rect, res1),
-            (Gray{Float32}, Float64.(rect), res1),
-            (Gray{Float32}, reshape(view(rect,:,:), 2,3), res1),
-            (Gray{Float32}, RGB{N0f8}.(rect), res1),
-            (Gray{Float32}, Augmentor.prepareaffine(rect), res1a),
-            (Gray{Float32}, OffsetArray(rect, -2, -1), res1b),
-            (Gray{Float32}, view(rect, IdentityRange(1:2), IdentityRange(1:3)), res1a),
-            (RGB{Float32}, rect, RGB{Float32}.(res1)),
-            (RGB{Float32}, OffsetArray(rect, -2, -1), RGB{Float32}.(res1b)),
+            (Float32, rect),
+            (Float32, OffsetArray(rect, -2, -1)),
+            (Gray{Float32}, rect),
+            (Gray{Float32}, Float64.(rect)),
+            (Gray{Float32}, reshape(view(rect,:,:), 2,3)),
+            (Gray{Float32}, RGB{N0f8}.(rect)),
+            (Gray{Float32}, Augmentor.prepareaffine(rect)),
+            (Gray{Float32}, OffsetArray(rect, -2, -1)),
+            (Gray{Float32}, view(rect, IdentityRange(1:2), IdentityRange(1:3))),
+            (RGB{Float32}, rect),
+            (RGB{Float32}, OffsetArray(rect, -2, -1))
         ]
         @testset "single image" begin
-            for (T, img_in, img_out) in imgs
+            for (T, img_in) in imgs
                 res = @inferred(Augmentor.applyeager(ConvertEltype(T), img_in))
-                @test res ≈ img_out
-                @test typeof(res) == typeof(img_out)
+                out = T.(img_out)
+                @test res ≈ out
+                @test typeof(res) <: typeof(out)
             end
         end
     end

--- a/test/operations/tst_crop.jl
+++ b/test/operations/tst_crop.jl
@@ -31,8 +31,8 @@
             for (img_in, inds) in imgs
                 res = @inferred(Augmentor.applyeager(Crop(1:2,2:3), img_in))
                 @test collect(res) == rect[1:2, 2:3]
-                @test axes(res) == inds
-                @test typeof(res) <: OffsetArray{eltype(img_in),2}
+                @test axes(res) == map(n->1:n, size(res)) # 1-base
+                @test typeof(res) <: Array{eltype(img_in),2}
             end
         end
         @testset "multiple images" begin
@@ -41,7 +41,7 @@
                 inds = (inds1, inds2)
                 res = @inferred(Augmentor.applyeager(Crop(1:2,2:3), img_in))
                 @test collect.(res) == ntuple(i->rect[1:2, 2:3],2)
-                @test typeof(res) <: NTuple{2,OffsetArray{eltype(img_in1),2}}
+                @test typeof(res) <: NTuple{2,Array{eltype(img_in1),2}}
             end
         end
     end
@@ -149,13 +149,13 @@ end
             for (img_in, inds) in imgs
                 res = @inferred(Augmentor.applyeager(CropNative(inds), img_in))
                 @test collect(res) == rect[1:2, 2:3]
-                @test axes(res) == inds
-                @test typeof(res) <: OffsetArray{eltype(img_in),2}
+                @test axes(res) == map(n->1:n, size(res)) # 1-base
+                @test typeof(res) <: Array{eltype(img_in),2}
             end
         end
         img = OffsetArray(rect, -2, -1)
         @test collect(@inferred(Augmentor.applyeager(CropNative(-1:0,1:2), img))) == rect[1:2, 2:3]
-        @test typeof(Augmentor.applyeager(CropNative(-1:0,1:2), img)) <: OffsetArray
+        @test typeof(Augmentor.applyeager(CropNative(-1:0,1:2), img)) <: Array
     end
     @testset "affine" begin
         @test Augmentor.supports_affine(CropNative) === false
@@ -278,8 +278,8 @@ end
             for (img_in, inds) in imgs
                 res = @inferred(Augmentor.applyeager(CropSize(2,2), img_in))
                 @test collect(res) == img_in[inds...]
-                @test axes(res) == inds
-                @test typeof(res) <: OffsetArray{eltype(img_in),2}
+                @test axes(res) == map(n->1:n, size(res)) # 1-base
+                @test typeof(res) <: Array{eltype(img_in),2}
             end
         end
         @testset "multiple images" begin
@@ -288,7 +288,7 @@ end
                 inds = (inds1, inds2)
                 res = @inferred(Augmentor.applyeager(CropSize(2,2), img_in))
                 @test collect.(res) == ntuple(i->img_in[i][inds[i]...],2)
-                @test typeof(res) <: NTuple{2,OffsetArray{eltype(img_in1),2}}
+                @test typeof(res) <: NTuple{2,Array{eltype(img_in1),2}}
             end
         end
     end
@@ -417,8 +417,8 @@ end
             for (img_in, inds) in imgs
                 res = @inferred(Augmentor.applyeager(CropRatio(1), img_in))
                 @test collect(res) == img_in[inds...]
-                @test axes(res) == inds
-                @test typeof(res) <: OffsetArray{eltype(img_in),2}
+                @test axes(res) == map(n->1:n, size(res)) # 1-base
+                @test typeof(res) <: Array{eltype(img_in),2}
             end
         end
         @testset "multiple images" begin
@@ -427,7 +427,7 @@ end
                 inds = (inds1, inds2)
                 res = @inferred(Augmentor.applyeager(CropRatio(1), img_in))
                 @test collect.(res) == ntuple(i->img_in[i][inds[i]...],2)
-                @test typeof(res) <: NTuple{2,OffsetArray{eltype(img_in1),2}}
+                @test typeof(res) <: NTuple{2,Array{eltype(img_in1),2}}
             end
         end
     end
@@ -553,8 +553,8 @@ end
             for (img_in, inds) in imgs
                 res = @inferred(Augmentor.applyeager(RCropRatio(3/2), img_in))
                 @test collect(res) == img_in[inds...]
-                @test axes(res) == inds
-                @test typeof(res) <: OffsetArray{eltype(img_in),2}
+                @test axes(res) == map(n->1:n, size(res)) # 1-base
+                @test typeof(res) <: Array{eltype(img_in),2}
             end
         end
         @testset "multiple images" begin
@@ -563,8 +563,8 @@ end
                 # make sure both images are processed
                 @test res1 == res2
                 @test axes(res1) == axes(res2)
-                @test typeof(res1) <: OffsetArray{Gray{N0f8}}
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res1) <: Array{Gray{N0f8}}
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end

--- a/test/operations/tst_dims.jl
+++ b/test/operations/tst_dims.jl
@@ -23,7 +23,7 @@
     @testset "eager" begin
         @test Augmentor.supports_eager(PermuteDims) === true
         @test @inferred(Augmentor.supports_eager(typeof(PermuteDims(2,1)))) === true
-        f = (img) -> permutedims(img, (2,1))
+        f = (img) -> collect(permutedims(img, (2,1)))
         imgs = [
             (rect),
             (Augmentor.prepareaffine(rect)),
@@ -74,7 +74,7 @@
                 @test_throws MethodError Augmentor.applylazy(PermuteDims(3,2,1), img_in)
                 res = @inferred(Augmentor.applylazy(PermuteDims(2,1), img_in))
                 @test res == img_out
-                @test res == Augmentor.applyeager(PermuteDims(2,1), img_in)
+                @test collect(res) == Augmentor.applyeager(PermuteDims(2,1), img_in)
                 @test typeof(res) == typeof(img_out)
             end
         end

--- a/test/operations/tst_noop.jl
+++ b/test/operations/tst_noop.jl
@@ -8,18 +8,16 @@ end
 @testset "eager" begin
     @test_throws MethodError Augmentor.applyeager(NoOp(), nothing)
     @test Augmentor.supports_eager(NoOp) === false
-    res1 = rect
-    res2 = OffsetArray(rect, -2, -1)
-    res3 = OffsetArray(rect, 0, 0)
+    img_out = rect
     imgs = [
-        (rect, res1),
-        (view(rect, :, :), res1),
-        (Augmentor.prepareaffine(rect), res3),
-        (OffsetArray(rect, -2, -1), res2),
-        (view(rect, IdentityRange(1:2), IdentityRange(1:3)), res3),
+        rect,
+        view(rect, :, :),
+        Augmentor.prepareaffine(rect),
+        OffsetArray(rect, -2, -1),
+        view(rect, IdentityRange(1:2), IdentityRange(1:3))
     ]
     @testset "single image" begin
-        for (img_in, img_out) in imgs
+        for img_in in imgs
             res = @inferred(Augmentor.applyeager(NoOp(), img_in))
             @test res == img_out
             @test typeof(res) == typeof(img_out)

--- a/test/operations/tst_rotation.jl
+++ b/test/operations/tst_rotation.jl
@@ -282,19 +282,17 @@ end
     @testset "eager" begin
         @test_throws MethodError Augmentor.applyeager(Rotate(10), nothing)
         @test Augmentor.supports_eager(Rotate) === false
-        res1 = OffsetArray(rotl90(square), 0, 0)
-        res2 = OffsetArray(rotl90(square), -1, -1)
-        res3 = OffsetArray(rotr90(square), 0, 0)
-        res4 = OffsetArray(rotr90(square), -1, -1)
+        img_out1 = rotl90(square)
+        img_out2 = rotr90(square)
         imgs = [
-            (square, res1, res3),
-            (view(square, :, :), res1, res3),
-            (Augmentor.prepareaffine(square), res1, res3),
-            (OffsetArray(square, -1, -1), res2, res4),
-            (view(square, IdentityRange(1:3), IdentityRange(1:3)), res1, res3),
+            square,
+            view(square, :, :),
+            Augmentor.prepareaffine(square),
+            OffsetArray(square, -1, -1),
+            view(square, IdentityRange(1:3), IdentityRange(1:3))
         ]
         @testset "fixed parameter" begin
-            for (img_in, img_out1, img_out2) in imgs
+            for img_in in imgs
                 res = @inferred(Augmentor.applyeager(Rotate(90), img_in))
                 @test res == img_out1
                 @test typeof(res) == typeof(img_out1)
@@ -306,12 +304,12 @@ end
                 @test res1 == img_out1
                 @test res2 == img_out1
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
                 res1, res2 = @inferred(Augmentor.applyeager(Rotate(-90), (img_in, N0f8.(img_in))))
                 @test res1 == img_out2
                 @test res2 == img_out2
                 @test typeof(res1) == typeof(img_out2)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
             # check that the affine map is computed for each image
             res1, res2 = @inferred(Augmentor.applyeager(Rotate(90), (square, square2)))
@@ -319,12 +317,12 @@ end
             @test res2 == OffsetArray(rotl90(square2), 0, 0)
         end
         @testset "random parameter" begin
-            for (img_in, img_out_type, _) in imgs
+            for img_in in imgs
                 res1, res2 = @inferred(Augmentor.applyeager(Rotate(1:90), (img_in, N0f8.(img_in))))
                 # make sure same angle is used
                 @test res1 == res2
-                @test typeof(res1) == typeof(img_out_type)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res1) == typeof(img_out1)
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end

--- a/test/operations/tst_scale.jl
+++ b/test/operations/tst_scale.jl
@@ -65,8 +65,8 @@
         # TODO: actual content tests (maybe test_reference)
         img_out1 = @inferred Augmentor.applyeager(Scale(1.5), square2)
         img_out2 = @inferred Augmentor.applyeager(Scale(0.2), square2)
-        @test axes(img_out1) == (0:5, 0:5)
-        @test axes(img_out2) == (2:3, 2:3)
+        @test axes(img_out1) == (1:6, 1:6)
+        @test axes(img_out2) == (1:2, 1:2)
         imgs = [
             (square2),
             (view(square2, :, :)),
@@ -87,17 +87,17 @@
                 @test cityblock(parent(res1), parent(img_out1)) <= 1e-2 # issue #38
                 @test cityblock(parent(res2), parent(img_out1)) <= 1e-2 # issue #38
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
                 res1, res2 = @inferred(Augmentor.applyeager(Scale(0.2), (img_in, N0f8.(img_in))))
                 @test parent(res1) ≈ parent(img_out2)
                 @test parent(res2) ==  parent(img_out2)
                 @test typeof(res1) == typeof(img_out2)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
             # check that the affine map is computed for each image
             res1, res2 = @inferred(Augmentor.applyeager(Scale(1.5), (square, OffsetArray(square,-5,-5))))
-            @test collect(res1) == collect(res2)
-            @test axes(res1) != axes(res2)
+            @test res1 == res2
+            @test axes(res1) == axes(res2)
         end
         @testset "random parameter" begin
             for img_in in imgs
@@ -105,7 +105,7 @@
                 # make sure same scales are used
                 @test res1 == res2
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end
@@ -114,7 +114,7 @@
         @test Augmentor.supports_affine(Scale) === true
         @test_throws MethodError Augmentor.applyaffine(Scale(90), nothing)
         wv = @inferred Augmentor.applyaffine(Scale(2,3), Augmentor.prepareaffine(square))
-        @test wv == ref
+        @test collect(wv) == ref
         # TODO: better tests
         @test parent(wv).itp.coefs === square
         @test typeof(wv) <: InvWarpedView{eltype(square),2}
@@ -123,7 +123,7 @@
         @test Augmentor.supports_affineview(Scale) === true
         @test_throws MethodError Augmentor.applyaffineview(Scale(90), nothing)
         wv = @inferred Augmentor.applyaffineview(Scale(2,3), Augmentor.prepareaffine(square))
-        @test wv == ref
+        @test collect(wv) == ref
         # TODO: better tests
         @test typeof(wv) <: SubArray{eltype(square),2}
         @test typeof(parent(wv)) <: InvWarpedView
@@ -132,7 +132,7 @@
     @testset "lazy" begin
         @test Augmentor.supports_lazy(Scale) === true
         wv = @inferred Augmentor.applylazy(Scale(2,3), square)
-        @test wv == ref
+        @test collect(wv) == ref
         # TODO: better tests
         @test parent(wv).itp.coefs === square
         @test typeof(wv) <: InvWarpedView{eltype(square),2}

--- a/test/operations/tst_shear.jl
+++ b/test/operations/tst_shear.jl
@@ -45,7 +45,7 @@
         # TODO: actual content tests (maybe test_reference)
         img_out1 = @inferred Augmentor.applyeager(ShearX(45), square)
         img_out2 = @inferred Augmentor.applyeager(ShearX(-45), square)
-        @test axes(img_out1) == (1:3, 0:4)
+        @test axes(img_out1) == (1:3, 1:5)
         @test axes(img_out1) == axes(img_out2)
         imgs = [
             (square),
@@ -67,17 +67,17 @@
                 @test parent(res1) == parent(img_out1)
                 @test parent(res2) == parent(img_out1)
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
                 res1, res2 = @inferred(Augmentor.applyeager(ShearX(-45), (img_in, N0f8.(img_in))))
                 @test parent(res1) == parent(img_out2)
                 @test parent(res2) == parent(img_out2)
                 @test typeof(res1) == typeof(img_out2)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
             # check that the affine map is computed for each image
             res1, res2 = @inferred(Augmentor.applyeager(ShearX(45), (square, OffsetArray(square,-5,-5))))
             @test collect(res1) == collect(res2)
-            @test axes(res1) != axes(res2)
+            @test axes(res1) == axes(res2)
         end
         @testset "random parameter" begin
             for img_in in imgs
@@ -85,7 +85,7 @@
                 # make sure same angle is used
                 @test res1 == res2
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end
@@ -186,7 +186,7 @@ end
         # TODO: actual content tests (maybe test_reference)
         img_out1 = @inferred Augmentor.applyeager(ShearY(45), square)
         img_out2 = @inferred Augmentor.applyeager(ShearY(-45), square)
-        @test axes(img_out1) == (0:4, 1:3)
+        @test axes(img_out1) == (1:5, 1:3)
         @test axes(img_out1) == axes(img_out2)
         imgs = [
             (square),
@@ -208,17 +208,17 @@ end
                 @test parent(res1) == parent(img_out1)
                 @test parent(res2) == parent(img_out1)
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
                 res1, res2 = @inferred(Augmentor.applyeager(ShearY(-45), (img_in, N0f8.(img_in))))
                 @test parent(res1) == parent(img_out2)
                 @test parent(res2) == parent(img_out2)
                 @test typeof(res1) == typeof(img_out2)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
             # check that the affine map is computed for each image
             res1, res2 = @inferred(Augmentor.applyeager(ShearY(45), (square, OffsetArray(square,-5,-5))))
             @test collect(res1) == collect(res2)
-            @test axes(res1) != axes(res2)
+            @test axes(res1) == axes(res2)
         end
         @testset "random parameter" begin
             for img_in in imgs
@@ -226,7 +226,7 @@ end
                 # make sure same angle is used
                 @test res1 == res2
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end

--- a/test/operations/tst_zoom.jl
+++ b/test/operations/tst_zoom.jl
@@ -88,17 +88,17 @@
                 @test cityblock(parent(res1), parent(img_out1)) <= 5e-3 # issue #38
                 @test cityblock(parent(res2), parent(img_out1)) <= 5e-3 # issue #38
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
                 res1, res2 = @inferred(Augmentor.applyeager(Zoom(0.2), (img_in, N0f8.(img_in))))
                 @test parent(res1) == parent(img_out2)
                 @test parent(res2) == parent(img_out2)
                 @test typeof(res1) == typeof(img_out2)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
             # check that the affine map is computed for each image
             res1, res2 = @inferred(Augmentor.applyeager(Zoom(1.5), (square, OffsetArray(square,-5,-5))))
-            @test collect(res1) == collect(res2)
-            @test axes(res1) != axes(res2)
+            @test res1 == res2
+            @test axes(res1) == axes(res2)
             res1, res2 = @inferred(Augmentor.applyeager(Zoom(1.5), (square, square2)))
             @test res1 == Augmentor.applyeager(Zoom(1.5), square)
             @test res2 == Augmentor.applyeager(Zoom(1.5), square2)
@@ -109,7 +109,7 @@
                 # make sure same scales are used
                 @test res1 == res2
                 @test typeof(res1) == typeof(img_out1)
-                @test typeof(res2) <: OffsetArray{N0f8}
+                @test typeof(res2) <: Array{N0f8}
             end
         end
     end

--- a/test/tst_augment.jl
+++ b/test/tst_augment.jl
@@ -79,8 +79,8 @@ end
 ops = (ShearY(45),ShearX(-2),CacheImage()) # forces affine then eager
 @testset "$(str_showcompact(ops))" begin
     img = @inferred Augmentor._augment(camera, ops)
-    @test typeof(img) <: OffsetArray
-    @test axes(img) == (-255:768, 0:512)
+    @test typeof(img) <: Array
+    @test axes(img) == (1:1024, 1:513)
 end
 
 ops = (Resize(2,2),Rotate90()) # forces affine
@@ -96,7 +96,7 @@ end
 ops = (Resize(2,2),Rotate90(),CacheImage()) # forces affine then eager
 @testset "$(str_showcompact(ops))" begin
     img = @inferred Augmentor._augment(rect, ops)
-    @test typeof(img) <: OffsetArray
+    @test typeof(img) <: Array
     @test round.(Float64.(img); digits=1) == round.(Float64.(rotl90(imresize(rect,2,2))); digits=1)
 end
 
@@ -104,7 +104,7 @@ buf = rand(Gray{N0f8}, 2, 2)
 ops = (Resize(2,2),Rotate90(),CacheImage(buf)) # forces affine then eager
 @testset "$(str_showcompact(ops))" begin
     img = @inferred Augmentor._augment(rect, ops)
-    @test typeof(img) <: OffsetArray
+    @test typeof(img) <: Array
     @test round.(Float64.(img); digits=1) == round.(Float64.(rotl90(imresize(rect,2,2))); digits=1)
     @test img == ops[3].buffer
     @test parent(img) === ops[3].buffer
@@ -333,8 +333,8 @@ ops = (Rotate(45),CropSize(200,200),Zoom(1.1),ConvertEltype(RGB{Float64}),SplitC
     @test wv3 == wv4
     @test typeof(wv3) == typeof(wv4)
     img = colorview(RGB{Float64}, wv3)
-    @test RGB{Float64}.(copy(wv1)) ≈ wv2
-    @test collect(wv1) ≈ img
+    @test RGB{Float64}.(collect(wv1)) ≈ img # collect(RGB{Float64}, wv1) returns OffsetArray
+    @test wv2 == img
     @test_reference "reference/rot45_crop_zoom_convert.txt" wv2
 end
 


### PR DESCRIPTION
It's more "eagerly" than `contiguous`, simplifies the codes and we can intuit the results more easily.

Previously there're operations followed by `plain_array`, `contiguous` and nothing. Since `plain_array` only strips the Offset wrapper on the top of `contiguous`, there shouldn't be any performance regression here.

- [x] I'll set a BenchmarkCI before merging this PR to ensure there's no performance regression (#49)

P.S. upgrading to OffsetArrays 1.0 is a little challenge with the over-verbose test cases; one breaking change is `axes(img_offset)` now returns tuple of `OffsetArrays.IdOffsetRange`. (Before that it's `Base.IdentityUnitRange` in julia v1.0 or `OffsetArrays.IdentityUnitRange` in julia >= v1.1 ). Hence I decided to strip the OffsetArray wrapper for eager mode augmentation.

@Evizero This PR might diverge what you expected in #24