### PR TITLE
update Rotations and remove ColorTypes and ImageInTerminal

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Christof Stocker <stocker.christof@gmail.com>"]
 version = "0.6.0-pre"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ComputationalResources = "ed09eef8-17a6-5b46-8889-db040fac31e3"
 CoordinateTransformations = "150eb455-5306-5404-9cee-2592286d6298"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
@@ -22,7 +21,6 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-ColorTypes = "0.7, 0.8"
 ComputationalResources = "0.3"
 CoordinateTransformations = "0.5"
 FileIO = "1"
@@ -34,7 +32,7 @@ Interpolations = "0.8, 0.9, 0.10, 0.11, 0.12"
 MLDataPattern = "0.4, 0.5"
 MappedArrays = "0.1, 0.2"
 OffsetArrays = "0.8, 0.9, 0.10, 0.11"
-Rotations = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12"
+Rotations = "0.7, 0.8, 0.9, 0.10, 0.11, 0.12, 0.13"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -38,7 +38,6 @@ julia = "1"
 
 [extras]
 ImageDistances = "51556ac3-7006-55f5-8cb3-34580c88182d"
-ImageInTerminal = "d8c32880-2388-543b-8c61-d9f865259254"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -46,4 +45,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [targets]
-test = ["ImageDistances", "ImageInTerminal", "ImageMagick", "ReferenceTests", "Statistics", "TestImages", "Test"]
+test = ["ImageDistances", "ImageMagick", "ReferenceTests", "Statistics", "TestImages", "Test"]

--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -1,6 +1,5 @@
 module Augmentor
 
-using ColorTypes
 using MappedArrays
 using ImageCore
 using ImageTransformations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,8 @@
-using ImageCore, ImageFiltering, ImageTransformations, CoordinateTransformations, Interpolations, OffsetArrays, StaticArrays, ColorTypes, TestImages, IdentityRanges, MappedArrays, ComputationalResources, MLDataPattern, ImageInTerminal, Statistics, ImageDistances
-using ReferenceTests, Test
+using ImageCore, ImageFiltering
+using ImageTransformations, CoordinateTransformations, Interpolations
+using MLDataPattern
+using OffsetArrays, StaticArrays, IdentityRanges, MappedArrays, ComputationalResources
+using ReferenceTests, Test, TestImages, ImageDistances, Statistics
 
 # check for ambiguities
 refambs = detect_ambiguities(ImageTransformations, Base, Core)


### PR DESCRIPTION
* ColorTypes is reexported by ImageCore >= v0.8.1
* ReferenceTests automatically loads ImageInTerminal

close #46
close #47