### PR TITLE
Introduce RCropSize() - Function for generating random crops of fixed size

### DIFF
--- a/src/Augmentor.jl
+++ b/src/Augmentor.jl
@@ -56,6 +56,7 @@ export
     CropSize,
     CropRatio,
     RCropRatio,
+    RCropSize,
 
     Resize,
 

--- a/src/operations/crop.jl
+++ b/src/operations/crop.jl
@@ -624,7 +624,8 @@ function rcropsize_axes(op::RCropSize, img::AbstractMatrix)
         y = safe_rand(1:y_max)
         return y:(y+nh-1), 1:w
     else
-        error("unreachable code reached")
+        # alternative behaviour could be to return the whole image or to pad
+        error("Trying to crop region of size ($nh, $nw) from image with size $(size(img)).")
     end
 end
 


### PR DESCRIPTION
Hi, I couldn't find a function to generate random crops of fixed size from a larger image, so I wrote one. If this was already possible this might be a bit embarrassing, because I didn't find out how - but anyway; it now works like a charm, including tests :-)

```julia
using ImageView, Augmentor
img = testimage()
pl = RCropSize(100)
imshow(augment(img, pl))
```

EDIT: Local test all pass - the failing tests are hopefully unrelated.