### PR TITLE
README: update link to supported operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Augmentor.jl provides:
 * `|>` operator to compose operations into a pipeline
 * higher-lvel functions (`augment`, `augment!` and `augmentbatch!`) that works on a pipeline and image(s).
 
-Check the [documentation](https://evizero.github.io/Augmentor.jl/stable/democards/operations/) for a full list of operations.
+Check the [documentation](https://evizero.github.io/Augmentor.jl/stable/operations/) for a full list of operations.
 
 ## Citing Augmentor
 


### PR DESCRIPTION
README contains a link to the documentation of the supported operations. The link no longer works, and this PR replaces it with the correct one.