### PR TITLE
Reduce CI workload

### DIFF
--- a/.github/workflows/juliapackage.yml
+++ b/.github/workflows/juliapackage.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - master
   pull_request:
-  schedule:
-    - cron: '20 00 1 * *'
 
 jobs:
   test:
@@ -17,7 +15,16 @@ jobs:
       fail-fast: false
       matrix:
         julia-version: ['1.0', '1', 'nightly']
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest]
+        arch: [x64]
+        include:
+          - os: windows-latest
+            julia-version: '1'
+            arch: x64
+          - os: macOS-latest
+            julia-version: '1'
+            arch: x64
+
 
     steps:
       - uses: actions/checkout@v2
@@ -25,6 +32,7 @@ jobs:
         uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.arch }}
 
       - name: Cache artifacts
         uses: actions/cache@v1
@@ -44,4 +52,3 @@ jobs:
       - uses: codecov/codecov-action@v1
         with:
           file: lcov.info
-            


### PR DESCRIPTION
In many cases, only run Julia 1.0 and nightly test on one platform Ubuntu should be sufficient enough to detect the failures.

Actions with cron jobs will be automatically disabled after 30/60 days of inactivity. For this reason, we can just remove it.