### PR TITLE
upgrade TagBot configuration

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,12 +1,16 @@
 name: TagBot
 on:
-  schedule:
-    - cron: 0 * * * *
+  issue_comment:
+    types:
+      - created
+  workflow_dispatch:
 jobs:
   TagBot:
+    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ssh: ${{ secrets.TAGBOT }}
+          


### PR DESCRIPTION
Since GitHub chose to disable cron jobs after 30/60 days of inactivity, TagBot took an alternative way to work things out, i.e., via issue comment #82.
We can safely unsubscribe from #82 because it's specifically for our TagBot CI.