### PR TITLE
Use `of_eltype` instead of convert lambda

### DIFF
--- a/src/operations/convert.jl
+++ b/src/operations/convert.jl
@@ -56,7 +56,7 @@ function applyeager(op::ConvertEltype{T}, img::AbstractArray, param) where T
 end
 
 function applylazy(op::ConvertEltype{T}, img::AbstractArray, param) where T
-    mappedarray(c->convert(T,c), img)
+    of_eltype(T, img)
 end
 
 function showconstruction(io::IO, op::ConvertEltype)

--- a/test/operations/tst_convert.jl
+++ b/test/operations/tst_convert.jl
@@ -57,21 +57,21 @@
         @test @inferred(Augmentor.supports_lazy(typeof(ConvertEltype(Gray{N0f8})))) === true
         let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray{Float32}), OffsetArray(rect,-2,-1)))
             @test parent(parent(img)) === rect
-            @test typeof(img) <: ReadonlyMappedArray{Gray{Float32},2}
+            @test typeof(img) <: MappedArray{Gray{Float32},2}
             @test axes(img) == (OffsetRange(-1:0), OffsetRange(0:2))
             @test img[0,0] isa Gray{Float32}
             @test collect(img) == convert.(Gray{Float32}, rect)
         end
         let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray{Float32}), Augmentor.prepareaffine(rect)))
             @test parent(parent(parent(parent(img)))) === rect
-            @test typeof(img) <: ReadonlyMappedArray{Gray{Float32},2}
+            @test typeof(img) <: MappedArray{Gray{Float32},2}
             @test axes(img) === (1:2, 1:3)
             @test img[1,1] isa Gray{Float32}
             @test collect(img) == convert.(Gray{Float32}, rect)
         end
         let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray{Float32}), view(rect, IdentityRange(1:2), IdentityRange(1:3))))
             @test parent(parent(img)) === rect
-            @test typeof(img) <: ReadonlyMappedArray{Gray{Float32},2}
+            @test typeof(img) <: MappedArray{Gray{Float32},2}
             @test axes(img) === (1:2, 1:3)
             @test img[1,1] isa Gray{Float32}
             @test collect(img) == convert.(Gray{Float32}, rect)
@@ -79,23 +79,23 @@
         let img = @inferred(Augmentor.applylazy(ConvertEltype(Gray{Float32}), rgb_rect))
             @test parent(img) === rgb_rect
             @test axes(img) === (Base.OneTo(2), Base.OneTo(3))
-            @test typeof(img) <: ReadonlyMappedArray{Gray{Float32},2}
+            @test typeof(img) <: MappedArray{Gray{Float32},2}
             @test img == convert.(Gray{Float32}, rgb_rect)
         end
         let img = @inferred(Augmentor.applylazy(ConvertEltype(Float32), checkers))
             @test parent(img) === checkers
             @test axes(img) === (Base.OneTo(3), Base.OneTo(5))
-            @test typeof(img) <: ReadonlyMappedArray{Float32,2}
+            @test typeof(img) <: MappedArray{Float32,2}
             @test img == convert(Array{Float32}, checkers)
         end
         let img = @inferred(Augmentor.applylazy(ConvertEltype(RGB{N0f8}), checkers))
             @test parent(img) === checkers
-            @test typeof(img) <: ReadonlyMappedArray{RGB{N0f8},2}
+            @test typeof(img) <: MappedArray{RGB{N0f8},2}
             @test img == convert.(RGB, checkers)
         end
         let img = @inferred(Augmentor.applylazy(ConvertEltype(RGB{Float64}), checkers))
             @test parent(img) === checkers
-            @test typeof(img) <: ReadonlyMappedArray{RGB{Float64},2}
+            @test typeof(img) <: MappedArray{RGB{Float64},2}
             @test img == convert.(RGB{Float64}, checkers)
         end
     end

--- a/test/operations/tst_convert.jl
+++ b/test/operations/tst_convert.jl
@@ -108,4 +108,19 @@
     @testset "permute" begin
         @test Augmentor.supports_permute(ConvertEltype) === false
     end
+    @testset "inference" begin
+        img = testpattern()
+        let pl = ConvertEltype(Gray)
+            aug_img = @inferred(augment(img, pl))
+            @test eltype(aug_img) <: Gray
+        end
+        let pl = SplitChannels() |> ConvertEltype(Gray)
+            aug_img = @inferred(augment(img, pl))
+            @test eltype(aug_img) <: Gray{N0f8}
+        end
+        let pl = ConvertEltype(Gray) |> SplitChannels()
+            aug_img = @inferred(augment(img, pl))
+            @test eltype(aug_img) <: N0f8
+        end
+    end
 end


### PR DESCRIPTION
As suggested by @timholy in #17, this PR changes `mappedarray(c->convert(T,c), img)` to `of_eltype(T, img)`. It results
in `MappedArray` instead of `ReadonlyMappedArray`, and it is more descriptive too.

This PR does not deal with #17, but I can confirm that the issue seems to be fixed already (which @johnnychen94 noticed before) and can be closed:

```julia
julia> using Augmentor, Test

julia> img = testpattern();

julia> @inferred(augment(img, ConvertEltype(Gray))) |> summary # Gray{Any}
"300×400 Array{Gray,2} with eltype Gray"

julia> pl = SplitChannels() |> ConvertEltype(Gray)
2-step Augmentor.ImmutablePipeline:
 1.) Split colorant into its color channels
 2.) Convert eltype to Gray

julia> @inferred(augment(img, pl)) |> summary # Gray{N0f8}
"4×300×400 Array{Gray{N0f8},3} with eltype Gray{FixedPointNumbers.N0f8}"
```